### PR TITLE
fix: Use zksolc 1.5.3 for contracts

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -38,7 +38,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "latest",
+    version: "1.5.3",
     settings: {
       // https://era.zksync.io/docs/tools/hardhat/hardhat-zksync-solc.html#configuration
       // Native AA calls an internal system contract, so it needs extra permissions


### PR DESCRIPTION
# Description
Update to use a specific version of `zksolc` for the hardcoded signatures in the Hardhat tests to pass.

## Verification Evidence
`npm run test -- --network hardhat` works locally again
![image](https://github.com/user-attachments/assets/7bc33c80-f847-4b10-b285-dcd692b552e1)

