### PR TITLE
fix: use address mapping for passkey storage

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -43,7 +43,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "1.5.4",
+    version: "1.5.6",
     settings: {
       // https://era.zksync.io/docs/tools/hardhat/hardhat-zksync-solc.html#configuration
       // Native AA calls an internal system contract, so it needs extra permissions

--- a/packages/contracts/src/AAFactory.sol
+++ b/packages/contracts/src/AAFactory.sol
@@ -5,7 +5,7 @@ import "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
 import "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
 
 import { IClaveAccount } from "./interfaces/IClaveAccount.sol";
-import "hardhat/console.sol";
+import "./helpers/Logger.sol";
 
 contract AAFactory {
   bytes32 public proxyAaBytecodeHash;
@@ -45,7 +45,9 @@ contract AAFactory {
     require(success, "Deployment failed");
 
     (accountAddress) = abi.decode(returnData, (address));
-    console.log("accountAddress %s", accountAddress);
+
+    Logger.logString("accountAddress");
+    Logger.logAddress(accountAddress);
 
     // add session-key/spend-limit module (similar code)
     IClaveAccount(accountAddress).initialize(initialValidators, initialModules, initialK1Owners);

--- a/packages/contracts/src/ClaveAccount.sol
+++ b/packages/contracts/src/ClaveAccount.sol
@@ -25,7 +25,7 @@ import { BatchCaller } from "./batch/BatchCaller.sol";
 
 import { IClaveAccount } from "./interfaces/IClaveAccount.sol";
 
-import "hardhat/console.sol";
+import "./helpers/Logger.sol";
 
 /**
  * @title Main account contract from the Clave wallet infrastructure in ZKsync Era
@@ -109,7 +109,7 @@ contract ClaveAccount is
     // should be checked explicitly to prevent user paying for fee for a
     // transaction that wouldn't be included on Ethereum.
     if (transaction.totalRequiredBalance() > address(this).balance) {
-      console.log("revert Errors.INSUFFICIENT_FUNDS()");
+      Logger.logString("revert Errors.INSUFFICIENT_FUNDS()");
       revert Errors.INSUFFICIENT_FUNDS();
     }
 
@@ -209,11 +209,12 @@ contract ClaveAccount is
     bytes32 signedHash,
     Transaction calldata transaction
   ) internal returns (bytes4 magicValue) {
-    console.log("_validateTransaction");
+    Logger.logString("_validateTransaction");
     if (transaction.signature.length == 65) {
-      console.log("transaction.signature.length == 65");
+      Logger.logString("transaction.signature.length == 65");
       (address signer, ) = ECDSA.tryRecover(signedHash, transaction.signature);
-      console.log("recovered signer", signer);
+      Logger.logString("recovered signer");
+      Logger.logAddress(signer);
       // gas estimation?
       if (signer == address(0)) {
         return bytes4(0);
@@ -226,13 +227,13 @@ contract ClaveAccount is
       transaction.signature
     );
 
-    console.log("validator address");
-    console.logAddress(validator);
+    Logger.logString("validator address");
+    Logger.logAddress(validator);
 
     // Run validation hooks
     bool hookSuccess = runValidationHooks(signedHash, transaction, hookData);
     if (!hookSuccess) {
-      console.log("failed hook validation");
+      Logger.logString("failed hook validation");
       return bytes4(0);
     }
 

--- a/packages/contracts/src/handlers/ValidationHandler.sol
+++ b/packages/contracts/src/handlers/ValidationHandler.sol
@@ -9,7 +9,7 @@ import { ValidatorManager } from "../managers/ValidatorManager.sol";
 import { IK1Validator, IR1Validator } from "../interfaces/IValidator.sol";
 import { IModuleValidator } from "../interfaces/IModuleValidator.sol";
 
-import "hardhat/console.sol";
+import "../helpers/Logger.sol";
 
 /**
  * @title ValidationHandler
@@ -47,7 +47,7 @@ abstract contract ValidationHandler is OwnerManager, ValidatorManager {
         return true;
       }
     } else if (_isModuleValidator(validator)) {
-      console.log("_isModuleValidator");
+      Logger.logString("_isModuleValidator");
       return IModuleValidator(validator).handleValidation(signedHash, signature);
     }
 

--- a/packages/contracts/src/helpers/Logger.sol
+++ b/packages/contracts/src/helpers/Logger.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// A wrapper for the hardhat console so we can disable it at compile time
+// instead of commenting out all the console.log statements :)
+pragma solidity ^0.8.24;
+
+import "hardhat/console.sol";
+
+library Logger {
+  function logString(string memory message) internal view {
+    if (block.chainid == 260) {
+      console.log(message);
+    }
+  }
+
+  function logAddress(address addressToLog) internal view {
+    if (block.chainid == 260) {
+      console.log(addressToLog);
+    }
+  }
+
+  function logBytes32(bytes32 bytesToLog) internal view {
+    if (block.chainid == 260) {
+      console.logBytes32(bytesToLog);
+    }
+  }
+
+  function logUint(uint intToLog) internal view {
+    if (block.chainid == 260) {
+      console.logUint(intToLog);
+    }
+  }
+
+  function logBool(bool boolToLog) internal view {
+    if (block.chainid == 260) {
+      console.logBool(boolToLog);
+    }
+  }
+}

--- a/packages/contracts/src/managers/ModuleManager.sol
+++ b/packages/contracts/src/managers/ModuleManager.sol
@@ -15,7 +15,7 @@ import { IModuleManager } from "../interfaces/IModuleManager.sol";
 import { IUserOpValidator } from "../interfaces/IERC7579Validator.sol";
 import { IERC7579Module, IExecutor } from "../interfaces/IERC7579Module.sol";
 
-import "hardhat/console.sol";
+import "../helpers/Logger.sol";
 
 /**
  * @title Manager contract for modules
@@ -66,7 +66,9 @@ abstract contract ModuleManager is IModuleManager, Auth {
 
   function _addNativeModule(address moduleAddress, bytes memory moduleData) internal {
     if (!_supportsModule(moduleAddress)) {
-      console.log("module", moduleAddress, "is not supported");
+      Logger.logString("module is not supported");
+      Logger.logAddress(moduleAddress);
+      // FIXME: support native modules on install
       // revert Errors.MODULE_ERC165_FAIL();
     }
 

--- a/packages/contracts/src/validators/PasskeyValidator.sol
+++ b/packages/contracts/src/validators/PasskeyValidator.sol
@@ -8,7 +8,7 @@ import { VerifierCaller } from "../helpers/VerifierCaller.sol";
 import { JsmnSolLib } from "../libraries/JsmnSolLib.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
-import "hardhat/console.sol";
+import "../helpers/Logger.sol";
 
 /**
  * @title validator contract for passkey r1 signatures

--- a/packages/contracts/src/validators/SessionPasskeySpendLimitModule.sol
+++ b/packages/contracts/src/validators/SessionPasskeySpendLimitModule.sol
@@ -10,7 +10,7 @@ import { IERC7579Module } from "../interfaces/IERC7579Module.sol";
 import { IR1Validator } from "../interfaces/IValidator.sol";
 import { IModuleValidator } from "../interfaces/IModuleValidator.sol";
 
-import "hardhat/console.sol";
+import "../helpers/Logger.sol";
 
 /**
  * Looking to combine with the validator to ensure that the spend limit is touched
@@ -64,7 +64,7 @@ contract SessionPasskeySpendLimitModule is IERC7579Module, IModule, IModuleValid
 
   // expects SessionKey[]
   function addValidationKey(bytes memory installData) external returns (bool) {
-    console.log("installing session-key spend-limit module");
+    Logger.logString("installing session-key spend-limit module");
     SessionKey[] memory sessionKeys = abi.decode(installData, (SessionKey[]));
     for (uint256 sessionKeyIndex = 0; sessionKeyIndex < sessionKeys.length; sessionKeyIndex++) {
       setSessionKey(sessionKeys[sessionKeyIndex]);
@@ -84,7 +84,7 @@ contract SessionPasskeySpendLimitModule is IERC7579Module, IModule, IModuleValid
   }
 
   function _install(bytes calldata installData) internal {
-    console.log("installing session-key spend-limit module");
+    Logger.logString("installing session-key spend-limit module");
     SessionKey[] memory sessionKeys = abi.decode(installData, (SessionKey[]));
     for (uint256 sessionKeyIndex = 0; sessionKeyIndex < sessionKeys.length; sessionKeyIndex++) {
       setSessionKey(sessionKeys[sessionKeyIndex]);
@@ -201,7 +201,7 @@ contract SessionPasskeySpendLimitModule is IERC7579Module, IModule, IModuleValid
 
     if (v != 27 && v != 28) {
       magic = bytes4(0);
-      console.log("session key signature v is invalid(27 or 28)");
+      Logger.logString("session key signature v is invalid(27 or 28)");
     }
 
     // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
@@ -215,22 +215,22 @@ contract SessionPasskeySpendLimitModule is IERC7579Module, IModule, IModuleValid
     // these malleable signatures as well.
     if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
       magic = bytes4(0);
-      console.log("session key signature s is too high");
+      Logger.logString("session key signature s is too high");
     }
 
     address recoveredAddress = ecrecover(_hash, v, r, s);
-    console.log("recoveredAddress(sessionKey)");
-    console.logAddress(recoveredAddress);
+    Logger.logString("recoveredAddress(sessionKey)");
+    Logger.logAddress(recoveredAddress);
 
     SessionData storage sessionData = spendLimitBySession[recoveredAddress];
-    console.log("sessionData.accountAddress");
-    console.logAddress(sessionData.accountAddress);
-    console.log("msg.sender");
-    console.logAddress(msg.sender);
+    Logger.logString("sessionData.accountAddress");
+    Logger.logAddress(sessionData.accountAddress);
+    Logger.logString("msg.sender");
+    Logger.logAddress(msg.sender);
     if (sessionData.accountAddress != msg.sender || recoveredAddress == address(0)) {
       // Note, that we should abstain from using the require here in order to allow for fee estimation to work
       magic = bytes4(0);
-      console.log("invalid session key");
+      Logger.logString("invalid session key");
     }
   }
 

--- a/packages/demo-app/project.json
+++ b/packages/demo-app/project.json
@@ -40,7 +40,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/demo-app",
-        "command": "playwright test"
+        "command": "playwright test --timeout 60000"
       },
       "dependsOn": ["e2e:setup"]
     },

--- a/packages/gateway/stores/client.ts
+++ b/packages/gateway/stores/client.ts
@@ -29,10 +29,10 @@ export const contractsByChain: Record<SupportedChainId, ChainContracts> = {
     accountImplementation: "0x",
   },
   [zksyncInMemoryNode.id]: {
-    session: "0x476F23ef274F244282252341792c8a610feF78ee",
-    passkey: "0x455e8d86DC6728396f8d3B740Fc893F4E20b25Dc",
+    session: "0xdCdAC285612841db9Fa732098EAF04A917A71A28",
+    passkey: "0xCeC63BD0f35e04F3Bef1128bA3A856A7BB4D88f1",
     accountFactory: "0x23b13d016E973C9915c6252271fF06cCA2098885",
-    accountImplementation: "0x6cd5A2354Be0E656e7A1E94F1C0570E08EC4789B",
+    accountImplementation: "0xdc78771361134e1Ae45f9AD23ec2C12B37A99ce8",
   },
 };
 


### PR DESCRIPTION
# Description

If my understanding is correct, (after having Lyova explain it to me), accounts should be able to access external contract storage given the storage is in a direct mapping from the account's address. This didn't work before because the array mapping wasn't a direct mapping, so I've changed it in hopes of it not getting blocked during validation.

## Additional context

This should unblock the ability to use passkeys on Sepolia without having to re-write the modular validator interface or update the storage.

I haven't deployed the demo app to sepolia myself to test this, as I still can't get the demo app e2e to pass locally.
Reviews and feedback appricated!