### PR TITLE
chore(nft-quest): improve deploy action

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -13,6 +13,13 @@
           "stake-demo-app"
         ]
       }
+    },
+    "nft-quest-testnet": {
+      "hosting": {
+        "nft-quest-testnet": [
+          "nft-quest-testnet"
+        ]
+      }
     }
   },
   "etags": {}

--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,12 @@
       "trailingSlash": false,
       "public": "packages/bank-demo/.output/public",
       "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "nft-quest-testnet",
+      "trailingSlash": false,
+      "public": "packages/nft-quest/.output/public",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
     }
   ]
 }

--- a/packages/bank-demo/README.md
+++ b/packages/bank-demo/README.md
@@ -38,5 +38,5 @@ The Bank demo app uses Demo Node (`https://node.nvillanueva.com`).
 4. Deploy the project to Firebase.
 
    ```bash
-   firebase deploy --only hosting:stake-demo-app --project stake-demo-app
+   pnpm nx deploy bank-demo
    ```

--- a/packages/bank-demo/project.json
+++ b/packages/bank-demo/project.json
@@ -18,6 +18,22 @@
       },
       "dependsOn": ["^build"]
     },
+    "deploy": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/bank-demo",
+        "command": "firebase deploy --only hosting:stake-demo-app --project stake-demo-app"
+      },
+      "dependsOn": ["build"]
+    },
+    "deploy:preview": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/nft-quest",
+        "command": "firebase hosting:channel:deploy --only stake-demo-app --project stake-demo-app"
+      },
+      "dependsOn": ["build"]
+    },
     "preview": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/nft-quest/README.md
+++ b/packages/nft-quest/README.md
@@ -12,7 +12,17 @@ pnpm nx deploy contracts
 
 # Deploy the contracts for the NFT Quest Demo
 pnpm nx deploy:local nft-quest-contracts
+```
 
+The contract addresses for the NFT Quest app will be set in `.env.local`. This
+.env file will override the values set in the `runtimeConfig` in
+`nuxt.config.ts`.
+
+You may also need to update the contract addresses for the Auth Server in
+`/packages/gateway/stores/client.ts` under the
+`contractsByChain[zksyncInMemoryNode.id]`
+
+```sh
 # Start the website and Auth Server
 pnpm nx dev nft-quest
 ```
@@ -29,4 +39,18 @@ and you can enable debug mode with:
 
 ```sh
 pnpm nx e2e:debug nft-quest
+```
+
+## Deploy the NFT Quest app to Firebase (WIP)
+
+The command to deploy for testnet:
+
+```sh
+pnpm nx deploy nft-quest
+```
+
+The command to deploy to a preview channel:
+
+```sh
+pnpm nx deploy:preview nft-quest <CHANNEL_NAME>
 ```

--- a/packages/nft-quest/components/zk/ButtonIcon.vue
+++ b/packages/nft-quest/components/zk/ButtonIcon.vue
@@ -13,12 +13,13 @@
 <script setup lang="ts">
 import { twMerge } from "tailwind-merge";
 
-import type { ButtonTypes, ButtonUI } from "./Button.vue";
+import type { ButtonTypes, ButtonUI } from "./button.vue";
 
 const {
   type = "ghost",
   icon,
-  ui = () => ({ button: {}, icon: "" }),
+  // eslint-disable-next-line vue/require-valid-default-prop
+  ui = { button: {}, icon: "" },
 } = defineProps<{
   type?: ButtonTypes;
   icon: string;

--- a/packages/nft-quest/nuxt.config.ts
+++ b/packages/nft-quest/nuxt.config.ts
@@ -19,6 +19,14 @@ export default defineNuxtConfig({
     preference: "dark",
   },
   devtools: { enabled: false },
+  // required for dealing with bigInt
+  nitro: {
+    esbuild: {
+      options: {
+        target: "esnext",
+      },
+    },
+  },
   app: {
     head: {
       link: [

--- a/packages/nft-quest/package.json
+++ b/packages/nft-quest/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "nuxt build",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare"

--- a/packages/nft-quest/project.json
+++ b/packages/nft-quest/project.json
@@ -16,7 +16,32 @@
             "prefix": "NFT-Quest:"
           }
         ]
-      }
+      },
+      "dependsOn": ["nft-quest-contracts:deploy:local"]
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/nft-quest",
+        "command": "pnpx nuxt generate"
+      },
+      "dependsOn": ["^build"]
+    },
+    "deploy": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/nft-quest",
+        "command": "firebase deploy --only hosting:nft-quest-testnet --project nft-quest-testnet"
+      },
+      "dependsOn": ["build"]
+    },
+    "deploy:preview": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/nft-quest",
+        "command": "firebase hosting:channel:deploy --only nft-quest-testnet --project nft-quest-testnet"
+      },
+      "dependsOn": ["build"]
     },
     "e2e:setup": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
# Description

Add some quality of life improvements and actions in anticipation of deploying the NFT Quest app to firebase.

## Additional context

- Add build, deploy, and deploy:preview commands in `project.json` for nft-quest app.
- Modified deploy script for nft-quest-contracts so that it sets the deployed smart contract addresses into a `.env.local` for nft-quest-app so that no manual edits are needed when working locally. Run `pnpm nx dev nft-quest` and it should build, deploy contracts and run the project with the addresses hooked up. 
- Add deploy and deploy:preview in `project.json` for bank-demo app. (Eventually we should be able to do a `pnpm nx affected -t deploy` and it will build and deploy affected projects)
-  Setup firebase hosting `nft-quest-testnet` for deployment. CI and secrets not configured yet for deployment.