### PR TITLE
chore: rename zksync-account to zksync-sso and optimize e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       run: pnpm nx deploy contracts
 
     # Run E2E tests
-    - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
+    - name: Install Playwright Chromium Browser
+      run: pnpm exec playwright install chromium
       working-directory: packages/demo-app
     - name: Run e2e tests
       run: pnpm nx e2e demo-app
@@ -99,8 +99,8 @@ jobs:
       run: pnpm nx deploy:local nft-quest-contracts
 
     # Run E2E tests
-    - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
+    - name: Install Playwright Chromium Browser
+      run: pnpm exec playwright install chromium
       working-directory: packages/nft-quest
     - name: Run e2e tests
       run: pnpm nx e2e nft-quest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This monorepo is comprised of the following packages/products:
 
-- `packages/sdk` is the `zksync-account` JavaScript SDK
+- `packages/sdk` is the `zksync-sso` JavaScript SDK
 - `packages/gateway` is the Gateway used for default account creation and
   session key management
 - `packages/contracts` are the on-chain smart contracts behind ZK Accounts

--- a/docs/sdk/client-gateway/README.md
+++ b/docs/sdk/client-gateway/README.md
@@ -9,7 +9,7 @@ application. It's built on top of [client SDK](../client/README.md) and
 ```ts
 import { zksync } from "viem/chains";
 import { createConfig, connect } from "@wagmi/core";
-import { zksyncAccountConnector } from "zksync-account/connector";
+import { zksyncAccountConnector } from "zksync-sso/connector";
 
 const ssoConnector = zksyncAccountConnector({
   // Optional session configuration

--- a/docs/sdk/client/README.md
+++ b/docs/sdk/client/README.md
@@ -9,7 +9,7 @@ development principles in mind.
 1. Register a new passkey
 
    ```ts
-   import { registerNewPasskey } from "zksync-account/client/passkey";
+   import { registerNewPasskey } from "zksync-sso/client/passkey";
 
    // We first need to register a new passkey
    const { credentialPublicKey } = await registerNewPasskey({
@@ -25,7 +25,7 @@ development principles in mind.
 
    ```ts
    import { generatePrivateKey, privateKeyToAddress } from "viem";
-   import { deployAccount } from "zksync-account/client";
+   import { deployAccount } from "zksync-sso/client";
 
    const deployerClient = ...; // Any client for deploying the account, make sure it has enough balance to cover the deployment cost
    const sessionKey = generatePrivateKey();
@@ -50,7 +50,7 @@ development principles in mind.
 
    ```ts
    import { zksync, http } from "viem";
-   import { createZksyncPasskeyClient } from "zksync-account/client/passkey";
+   import { createZksyncPasskeyClient } from "zksync-sso/client/passkey";
 
    const passkeyClient = createZksyncPasskeyClient({
      address: deployedAccountAddress,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript-eslint": "8.7.0",
     "viem": "^2.21.14",
     "verdaccio": "6.0.0",
-    "zksync-account": "workspace:*"
+    "zksync-sso": "workspace:*"
   },
   "nx": {
     "includedScripts": []

--- a/packages/bank-demo/components/app/AddCryptoButton.vue
+++ b/packages/bank-demo/components/app/AddCryptoButton.vue
@@ -14,8 +14,8 @@
 <script setup lang="ts">
 import { createWalletClient, http, type Address, type Chain } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { deployAccount } from "zksync-account/client";
-import { registerNewPasskey } from "zksync-account/client/passkey";
+import { deployAccount } from "zksync-sso/client";
+import { registerNewPasskey } from "zksync-sso/client/passkey";
 
 const { appMeta, userDisplay, userId, contracts, deployerKey } = useAppMeta();
 const isLoading = ref(false);

--- a/packages/bank-demo/package.json
+++ b/packages/bank-demo/package.json
@@ -25,6 +25,6 @@
     "viem": "^2.21.14",
     "vue": "latest",
     "vue-router": "latest",
-    "zksync-account": "workspace:*"
+    "zksync-sso": "workspace:*"
   }
 }

--- a/packages/bank-demo/pages/crypto-account.vue
+++ b/packages/bank-demo/pages/crypto-account.vue
@@ -245,7 +245,7 @@
 
 <script setup lang="ts">
 import { createPublicClient, formatEther, http, parseEther, TransactionExecutionError, type Address, type Chain } from "viem";
-import { createZksyncPasskeyClient } from "zksync-account/client/passkey";
+import { createZksyncPasskeyClient } from "zksync-sso/client/passkey";
 import OnRampCrypto from "~/components/app/OnRampCrypto.vue";
 
 const { appMeta, userDisplay, userId, contracts, aaveAddress, explorerUrl } = useAppMeta();

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zksync-account-sdk-contracts",
+  "name": "zksync-sso-sdk-contracts",
   "description": "Smart contracts for modular account deployment",
   "private": true,
   "author": "Matter Labs",
@@ -46,6 +46,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
     "viem": "^2.21.6",
-    "zksync-account": "workspace:*"
+    "zksync-sso": "workspace:*"
   }
 }

--- a/packages/contracts/test/sdk/PasskeyClient.ts
+++ b/packages/contracts/test/sdk/PasskeyClient.ts
@@ -1,6 +1,6 @@
 import { type Account, type Address, type Chain, type Client, createClient, getAddress, type Prettify, type PublicActions, publicActions, type PublicRpcSchema, type RpcSchema, type Transport, type WalletActions, walletActions, type WalletClientConfig, type WalletRpcSchema } from "viem";
-import { toSmartAccount } from "zksync-account/client/smart-account";
-import { passkeyHashSignatureResponseFormat } from "zksync-account/utils";
+import { toSmartAccount } from "zksync-sso/client/smart-account";
+import { passkeyHashSignatureResponseFormat } from "zksync-sso/utils";
 
 export function createZksyncPasskeyClient<
   transport extends Transport,

--- a/packages/contracts/test/utils.ts
+++ b/packages/contracts/test/utils.ts
@@ -6,8 +6,8 @@ import { ethers, parseEther } from "ethers";
 import { readFileSync } from "fs";
 import { promises } from "fs";
 import * as hre from "hardhat";
-import { base64UrlToUint8Array, getPublicKeyBytesFromPasskeySignature, unwrapEC2Signature } from "zksync-account/utils";
 import { ContractFactory, Provider, utils, Wallet } from "zksync-ethers";
+import { base64UrlToUint8Array, getPublicKeyBytesFromPasskeySignature, unwrapEC2Signature } from "zksync-sso/utils";
 
 import { AAFactory, ERC20, ERC7579Account, ExampleAuthServerPaymaster, SessionKeyValidator, WebAuthValidator } from "../typechain-types";
 import { AAFactory__factory, ERC20__factory, ERC7579Account__factory, ExampleAuthServerPaymaster__factory, SessionKeyValidator__factory, WebAuthValidator__factory } from "../typechain-types";

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -20,7 +20,7 @@
     "viem": "2.21.14",
     "vue": "^3.4.21",
     "wagmi": "^2.12.17",
-    "zksync-account": "workspace:*",
+    "zksync-sso": "workspace:*",
     "zksync-ethers": "^6.12.1"
   },
   "devDependencies": {

--- a/packages/demo-app/pages/index.vue
+++ b/packages/demo-app/pages/index.vue
@@ -24,6 +24,7 @@
     <button
       v-if="address"
       class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+      :disabled="isSendingEth"
       @click="sendTokens()"
     >
       Send 0.1 ETH
@@ -40,7 +41,7 @@
 
 <script lang="ts" setup>
 import { disconnect, getBalance, watchAccount, sendTransaction, createConfig, connect, reconnect, type GetBalanceReturnType } from "@wagmi/core";
-import { zksyncAccountConnector } from "zksync-account/connector";
+import { zksyncAccountConnector } from "zksync-sso/connector";
 import { zksyncInMemoryNode } from "@wagmi/core/chains";
 import { createWalletClient, http, parseEther, type Address } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -70,6 +71,7 @@ reconnect(wagmiConfig);
 const address = ref<Address | null>(null);
 const balance = ref<GetBalanceReturnType | null>(null);
 const errorMessage = ref<string | null>(null);
+const isSendingEth = ref<boolean>(false);
 
 const fundAccount = async () => {
   if (!address.value) throw new Error("Not connected");
@@ -133,6 +135,7 @@ const sendTokens = async () => {
   if (!address.value) return;
 
   errorMessage.value = "";
+  isSendingEth.value = true;
   try {
     await sendTransaction(wagmiConfig, {
       to: testTransferTarget,
@@ -158,6 +161,8 @@ const sendTokens = async () => {
     } else {
       errorMessage.value = "Transaction failed, see console for more info.";
     }
+  } finally {
+    isSendingEth.value = false;
   }
 };
 </script>

--- a/packages/demo-app/tests/create-account.spec.ts
+++ b/packages/demo-app/tests/create-account.spec.ts
@@ -103,7 +103,7 @@ test("Create account, session key, and send ETH", async ({ page }) => {
 
   // Send some eth
   await page.getByRole("button", { name: "Send 0.1 ETH" }).click();
-  await page.waitForTimeout(2000);
+  await expect(page.getByRole("button", { name: "Send 0.1 ETH" })).toBeEnabled();
   const endBalance = +(await page.getByText("Balance:").innerText())
     .replace("Balance: ", "")
     .replace(" ETH", "");

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -1,3 +1,3 @@
-# zksync-account-gateway
+# zksync-sso-gateway
 
 ZKsync Account Gateway

--- a/packages/gateway/components/views/Connect.vue
+++ b/packages/gateway/components/views/Connect.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { SessionPreferences } from "zksync-account";
+import type { SessionPreferences } from "zksync-sso";
 
 const { request } = storeToRefs(useRequestsStore());
 

--- a/packages/gateway/components/views/Login.vue
+++ b/packages/gateway/components/views/Login.vue
@@ -59,8 +59,8 @@
 <script lang="ts" setup>
 import { type Address, toHex } from "viem";
 import { zksyncInMemoryNode, zksyncLocalNode } from "viem/chains";
-import { deployAccount, fetchAccount } from "zksync-account/client";
-import { registerNewPasskey } from "zksync-account/client/passkey";
+import { deployAccount, fetchAccount } from "zksync-sso/client";
+import { registerNewPasskey } from "zksync-sso/client/passkey";
 
 const { appMeta } = useAppMeta();
 const { login } = useAccountStore();

--- a/packages/gateway/components/views/confirmation/RequestAccounts.vue
+++ b/packages/gateway/components/views/confirmation/RequestAccounts.vue
@@ -60,7 +60,7 @@
 <script lang="ts" setup>
 import { CheckIcon } from "@heroicons/vue/24/outline";
 import Web3Avatar from "web3-avatar-vue";
-import type { ExtractReturnType, GatewayRpcSchema } from "zksync-account/client-gateway";
+import type { ExtractReturnType, GatewayRpcSchema } from "zksync-sso/client-gateway";
 
 const { appMeta, domain } = useAppMeta();
 const { respond, deny } = useRequestsStore();

--- a/packages/gateway/components/views/confirmation/RequestSession.vue
+++ b/packages/gateway/components/views/confirmation/RequestSession.vue
@@ -115,9 +115,9 @@ import { ChevronDownIcon } from "@heroicons/vue/24/outline";
 import { useTimeAgo } from "@vueuse/core";
 import { type Address, formatUnits } from "viem";
 import { generatePrivateKey, privateKeyToAddress } from "viem/accounts";
-import type { SessionPreferences } from "zksync-account";
-import type { ExtractReturnType, GatewayRpcSchema } from "zksync-account/client-gateway";
-import { getSession } from "zksync-account/utils";
+import type { SessionPreferences } from "zksync-sso";
+import type { ExtractReturnType, GatewayRpcSchema } from "zksync-sso/client-gateway";
+import { getSession } from "zksync-sso/utils";
 
 const props = defineProps({
   session: {

--- a/packages/gateway/components/views/confirmation/Send.vue
+++ b/packages/gateway/components/views/confirmation/Send.vue
@@ -144,7 +144,7 @@ import { useIntervalFn } from "@vueuse/core";
 import { type Address, formatUnits } from "viem";
 import { chainConfig, type ZksyncRpcTransaction } from "viem/zksync";
 import Web3Avatar from "web3-avatar-vue";
-import type { ExtractParams } from "zksync-account/client-gateway";
+import type { ExtractParams } from "zksync-sso/client-gateway";
 
 const { appMeta } = useAppMeta();
 const { respond, deny } = useRequestsStore();

--- a/packages/gateway/composables/useAccountRegistration.ts
+++ b/packages/gateway/composables/useAccountRegistration.ts
@@ -1,7 +1,7 @@
 import { type Address, parseEther, toHex } from "viem";
 import { zksyncInMemoryNode } from "viem/chains";
-import { deployAccount } from "zksync-account/client";
-import { registerNewPasskey } from "zksync-account/client/passkey";
+import { deployAccount } from "zksync-sso/client";
+import { registerNewPasskey } from "zksync-sso/client/passkey";
 
 import { useAccountFetch } from "./useAccountFetch";
 

--- a/packages/gateway/composables/useAppMeta.ts
+++ b/packages/gateway/composables/useAppMeta.ts
@@ -1,5 +1,5 @@
 import { useStorage } from "@vueuse/core";
-import type { AppMetadata } from "zksync-account";
+import type { AppMetadata } from "zksync-sso";
 
 export const useAppMeta = () => {
   const route = useRoute();

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -29,7 +29,7 @@
     "vue": "latest",
     "wagmi": "^2.12.17",
     "web3-avatar-vue": "^1.0.4",
-    "zksync-account": "workspace:*"
+    "zksync-sso": "workspace:*"
   },
   "overrides": {
     "vue": "latest"

--- a/packages/gateway/stores/client.ts
+++ b/packages/gateway/stores/client.ts
@@ -2,7 +2,7 @@ import { type Address, createPublicClient, createWalletClient, http, publicActio
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { zksync, zksyncInMemoryNode, zksyncLocalNode, zksyncSepoliaTestnet } from "viem/chains";
 import { eip712WalletActions } from "viem/zksync";
-import { createZksyncPasskeyClient, type PasskeyRequiredContracts } from "zksync-account/client/passkey";
+import { createZksyncPasskeyClient, type PasskeyRequiredContracts } from "zksync-sso/client/passkey";
 
 export const supportedChains = [zksync, zksyncSepoliaTestnet, zksyncInMemoryNode, zksyncLocalNode];
 export type SupportedChainId = (typeof supportedChains)[number]["id"];

--- a/packages/gateway/stores/requests.ts
+++ b/packages/gateway/stores/requests.ts
@@ -1,4 +1,4 @@
-import type { ExtractParams, ExtractReturnType, GatewayRpcSchema, Method, RPCRequestMessage, RPCResponseMessage } from "zksync-account/client-gateway";
+import type { ExtractParams, ExtractReturnType, GatewayRpcSchema, Method, RPCRequestMessage, RPCResponseMessage } from "zksync-sso/client-gateway";
 
 export const useRequestsStore = defineStore("requests", () => {
   const { appMeta } = useAppMeta();

--- a/packages/gateway/utils/communicator.ts
+++ b/packages/gateway/utils/communicator.ts
@@ -1,4 +1,4 @@
-import type { Message, PopupConfigMessage } from "zksync-account/communicator";
+import type { Message, PopupConfigMessage } from "zksync-sso/communicator";
 
 /**
  * Communicates within a popup window to receive and respond to messages.

--- a/packages/nft-quest/package.json
+++ b/packages/nft-quest/package.json
@@ -36,7 +36,7 @@
     "vue": "latest",
     "vue-load-image": "^1.1.0",
     "vue-router": "latest",
-    "zksync-account": "workspace:*",
+    "zksync-sso": "workspace:*",
     "zksync-ethers": "^6.14.0"
   },
   "devDependencies": {

--- a/packages/nft-quest/stores/connector.ts
+++ b/packages/nft-quest/stores/connector.ts
@@ -1,8 +1,8 @@
 import { connect, createConfig, type CreateConnectorFn, disconnect, getAccount, http, reconnect, watchAccount } from "@wagmi/core";
 import { type Address, type Hash, parseEther, toFunctionSelector } from "viem";
 import { zksyncInMemoryNode } from "viem/zksync";
-import { zksyncAccountConnector } from "zksync-account/connector";
-import { getSession } from "zksync-account/utils";
+import { zksyncAccountConnector } from "zksync-sso/connector";
+import { getSession } from "zksync-sso/utils";
 
 export const supportedChains = [zksyncInMemoryNode] as const;
 export type SupportedChainId = (typeof supportedChains)[number]["id"];

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,3 +1,3 @@
-# zksync-account-sdk
+# zksync-sso-sdk
 
 ZKsync Account SDK

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
-  "name": "zksync-account",
-  "description": "ZKsync Smart Account SDK",
+  "name": "zksync-sso",
+  "description": "ZKsync Smart Sign On SDK",
   "version": "0.0.0-development",
   "publishConfig": {
     "registry": "http://localhost:4873"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
       viem:
         specifier: ^2.21.14
         version: 2.21.14(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.22.4)
-      zksync-account:
+      zksync-sso:
         specifier: workspace:*
         version: link:packages/sdk
 
@@ -159,7 +159,7 @@ importers:
       vue-router:
         specifier: latest
         version: 4.4.5(vue@3.5.12(typescript@5.6.2))
-      zksync-account:
+      zksync-sso:
         specifier: workspace:*
         version: link:../sdk
 
@@ -195,7 +195,7 @@ importers:
       viem:
         specifier: ^2.21.6
         version: 2.21.14(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.22.4)
-      zksync-account:
+      zksync-sso:
         specifier: workspace:*
         version: link:../sdk
     devDependencies:
@@ -319,12 +319,12 @@ importers:
       wagmi:
         specifier: ^2.12.17
         version: 2.12.25(@tanstack/query-core@5.59.16)(@tanstack/react-query@5.59.16(react@18.3.1))(bufferutil@4.0.8)(ioredis@5.4.1)(react-native@0.76.0(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)(viem@2.21.14(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
-      zksync-account:
-        specifier: workspace:*
-        version: link:../sdk
       zksync-ethers:
         specifier: ^6.12.1
         version: 6.14.0(ethers@6.13.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      zksync-sso:
+        specifier: workspace:*
+        version: link:../sdk
     devDependencies:
       '@nuxt/eslint':
         specifier: ^0.5.7
@@ -401,7 +401,7 @@ importers:
       web3-avatar-vue:
         specifier: ^1.0.4
         version: 1.0.4(typescript@5.6.2)
-      zksync-account:
+      zksync-sso:
         specifier: workspace:*
         version: link:../sdk
 
@@ -491,12 +491,12 @@ importers:
       vue-router:
         specifier: latest
         version: 4.4.5(vue@3.5.12(typescript@5.6.2))
-      zksync-account:
-        specifier: workspace:*
-        version: link:../sdk
       zksync-ethers:
         specifier: ^6.14.0
         version: 6.14.0(ethers@6.13.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      zksync-sso:
+        specifier: workspace:*
+        version: link:../sdk
     devDependencies:
       '@nuxtjs/tailwindcss':
         specifier: ^6.12.0


### PR DESCRIPTION
# Description
* Rename `zksync-account` JavaScript SDK to `zksync-sso`
* Also updated the e2e tests for `demo-app` to be more stable and for e2e test setup in CI to be faster
