### PR TITLE
fix: remove hardcoded reference to in memory node in nft-quest

### DIFF
--- a/packages/nft-quest/composables/useMintNft.ts
+++ b/packages/nft-quest/composables/useMintNft.ts
@@ -2,8 +2,6 @@ import { estimateGas, waitForTransactionReceipt, writeContract } from "@wagmi/co
 import { type Address, encodeFunctionData } from "viem";
 import { getGeneralPaymasterInput } from "viem/zksync";
 
-import { supportedChains } from "~/stores/connector";
-
 export const useMintNft = async (_address: MaybeRef<Address>) => {
   const address = toRef(_address);
 
@@ -22,7 +20,7 @@ export const useMintNft = async (_address: MaybeRef<Address>) => {
     const estimatedGas = await estimateGas(wagmiConfig.value, {
       account: account.value.address,
       to: runtimeConfig.public.contracts.nft as Address,
-      chainId: supportedChains[0].id,
+      chainId: runtimeConfig.public.chain.id,
       data,
     });
 

--- a/packages/nft-quest/stores/connector.ts
+++ b/packages/nft-quest/stores/connector.ts
@@ -1,14 +1,17 @@
 import { connect, createConfig, type CreateConnectorFn, disconnect, getAccount, http, reconnect, watchAccount } from "@wagmi/core";
 import { type Address, type Hash, parseEther, toFunctionSelector } from "viem";
-import { zksyncInMemoryNode } from "viem/zksync";
+import { zksyncInMemoryNode, zksyncLocalNode, zksyncSepoliaTestnet } from "viem/chains";
 import { zksyncAccountConnector } from "zksync-sso/connector";
 import { getSession } from "zksync-sso/utils";
 
-export const supportedChains = [zksyncInMemoryNode] as const;
-export type SupportedChainId = (typeof supportedChains)[number]["id"];
-
 export const useConnectorStore = defineStore("connector", () => {
   const runtimeConfig = useRuntimeConfig();
+  const supportedChains = [
+    zksyncSepoliaTestnet,
+    zksyncInMemoryNode,
+    zksyncLocalNode,
+  ].filter((x) => x.id == runtimeConfig.public.chain.id);
+  type SupportedChainId = (typeof supportedChains)[number]["id"];
 
   const connector = zksyncAccountConnector({
     metadata: {


### PR DESCRIPTION
# Description
Remove hardcoded reference to `zksyncInMemoryNode` in nft-quest app
