### PR TITLE
chore: update sepolia addresses after session validator updates

### DIFF
--- a/packages/auth-server/stores/client.ts
+++ b/packages/auth-server/stores/client.ts
@@ -21,10 +21,10 @@ type ChainContracts = PasskeyRequiredContracts & {
 };
 export const contractsByChain: Record<SupportedChainId, ChainContracts> = {
   [zksyncSepoliaTestnet.id]: {
-    session: "0xA36629B817C3218F8E44bc5a0d0E64C58eE69Fef",
+    session: "0x360A6930cD57175fD2fc21BF331C777EB7b522d6",
     passkey: "0x7AC1718A54372B5D5fDAca2B7aB6dC6019078d20",
     accountFactory: "0xD0CDc89E09dff81571D96465dFcf6737454C4AFe",
-    accountPaymaster: "0x8f8f4f03c3174ba92f131d8dfc137881A896ea3E",
+    accountPaymaster: "0x5B9DDEc14fDD2264b199c531C6E25e4bb6F5a4f2",
   },
   [zksyncInMemoryNode.id]: {
     session: "0x8543528a4561E3a5EC7d51Bfd3776457b0E7b7dc",


### PR DESCRIPTION
# Description
Update Sepolia addresses after #170 was merged

```sh
"SessionKeyValidator" was successfully deployed to 0x360A6930cD57175fD2fc21BF331C777EB7b522d6
Requesting contract verification...
src/validators/SessionKeyValidator.sol:SessionKeyValidator
Your verification ID is: 31994
"ExampleAuthServerPaymaster" was successfully deployed to 0x5B9DDEc14fDD2264b199c531C6E25e4bb6F5a4f2
Requesting contract verification...
src/test/ExampleAuthServerPaymaster.sol:ExampleAuthServerPaymaster
Your verification ID is: 31995
Contract successfully verified on ZKsync block explorer!
Session Address                : 0x360A6930cD57175fD2fc21BF331C777EB7b522d6
Auth Server Paymaster Address  : 0x5B9DDEc14fDD2264b199c531C6E25e4bb6F5a4f2
    ✔ should deploy all contracts (31905ms)
```