### PR TITLE
fix: disable user verification

### DIFF
--- a/packages/sdk/src/client/actions/passkey.ts
+++ b/packages/sdk/src/client/actions/passkey.ts
@@ -40,7 +40,9 @@ export const generatePasskeyRegistrationOptions = async (args: GeneratePasskeyRe
     // See "Guiding use of authenticators via authenticatorSelection" below
     authenticatorSelection: {
       residentKey: "required",
+      userVerification: "discouraged",
     },
+    supportedAlgorithmIDs: [-7], // only supports ES256 (no windows hello)
   };
   const params: GenerateRegistrationOptionsOpts = Object.assign({}, defaultOptions, args);
   const options = await generateRegistrationOptions(params);


### PR DESCRIPTION

# Description

We have a user who is getting this error even when it defaults to preferred, and we're discouraging it in other places. Also attempting to block Windows Hello before hasn't been successful, as Chrome thinks we should be able to support it.

## Additional context

* The error he's seeing is "user verification required, but user could not be verified", so discouraging user verification should help.
* Windows uses RS256 for passkeys, which we don't support. Past attempts at blocking this algorithm have been unsuccessful.


# Evidence

Signing in with Windows (on edge) works when using the "use mobile authenticator" option.
![image](https://github.com/user-attachments/assets/34c4e21a-263f-44b9-af7c-34d3bc1930e3)

Changing the supported algorithms didn't change Windows showing PIN/FaceId, and it looks like it worked at least within the PR, so it's possible that Windows Hello can use ES256? It could also just be the test setup here.
