### PR TITLE
fix: make factory proxy work

### DIFF
--- a/src/AAFactory.sol
+++ b/src/AAFactory.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import { DEPLOYER_SYSTEM_CONTRACT, IContractDeployer } from "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
 import { SystemContractsCaller } from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
 
@@ -11,7 +10,7 @@ import { ISsoAccount } from "./interfaces/ISsoAccount.sol";
 /// @author Matter Labs
 /// @custom:security-contact security@matterlabs.dev
 /// @dev This contract is used to deploy SSO accounts as beacon proxies.
-contract AAFactory is UpgradeableBeacon {
+contract AAFactory {
   /// @notice Emitted when a new account is successfully created.
   /// @param accountAddress The address of the newly created account.
   /// @param uniqueAccountId A unique identifier for the account.
@@ -19,15 +18,17 @@ contract AAFactory is UpgradeableBeacon {
 
   /// @dev The bytecode hash of the beacon proxy, used for deploying proxy accounts.
   bytes32 private immutable beaconProxyBytecodeHash;
+  address private immutable beacon;
 
   /// @notice A mapping from unique account IDs to their corresponding deployed account addresses.
   mapping(string => address) public accountMappings;
 
   /// @notice Constructor that initializes the factory with a beacon proxy bytecode hash and implementation contract address.
   /// @param _beaconProxyBytecodeHash The bytecode hash of the beacon proxy.
-  /// @param _implementation The address of the implementation contract used by the beacon.
-  constructor(bytes32 _beaconProxyBytecodeHash, address _implementation) UpgradeableBeacon(_implementation) {
+  /// @param _beacon The address of the UpgradeableBeacon contract used for the SSO accounts' beacon proxies.
+  constructor(bytes32 _beaconProxyBytecodeHash, address _beacon) {
     beaconProxyBytecodeHash = _beaconProxyBytecodeHash;
+    beacon = _beacon;
   }
 
   /// @notice Deploys a new SSO account as a beacon proxy with the specified parameters.
@@ -52,12 +53,7 @@ contract AAFactory is UpgradeableBeacon {
       uint128(0),
       abi.encodeCall(
         DEPLOYER_SYSTEM_CONTRACT.create2Account,
-        (
-          _salt,
-          beaconProxyBytecodeHash,
-          abi.encode(address(this)),
-          IContractDeployer.AccountAbstractionVersion.Version1
-        )
+        (_salt, beaconProxyBytecodeHash, abi.encode(beacon), IContractDeployer.AccountAbstractionVersion.Version1)
       )
     );
     require(success, "Deployment failed");

--- a/src/SsoBeacon.sol
+++ b/src/SsoBeacon.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+/// @title SsoBeacon
+/// @author Matter Labs
+/// @custom:security-contact security@matterlabs.dev
+contract SsoBeacon is UpgradeableBeacon {
+  constructor(address _implementation) UpgradeableBeacon(_implementation) {}
+}

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -6,8 +6,8 @@ import { it } from "mocha";
 import { SmartAccount, utils } from "zksync-ethers";
 
 import type { ERC20 } from "../typechain-types";
-import { AAFactory__factory, SsoAccount__factory } from "../typechain-types";
-import type { AAFactory } from "../typechain-types/src/AAFactory";
+import { SsoBeacon__factory, SsoAccount__factory } from "../typechain-types";
+import type { SsoBeacon } from "../typechain-types/src/SsoBeacon";
 import type { SessionLib } from "../typechain-types/src/validators/SessionKeyValidator";
 import { ContractFixtures, getProvider, logInfo } from "./utils";
 
@@ -367,6 +367,8 @@ describe("SessionKeyModule tests", function () {
     assert(sessionModuleContract != null, "No session module deployed");
     const ssoContract = await fixtures.getAccountImplContract();
     assert(ssoContract != null, "No SSO Account deployed");
+    const beaconContract = await fixtures.getBeaconContract();
+    assert(beaconContract != null, "No Beacon deployed");
     const factoryContract = await fixtures.getAaFactory();
     assert(factoryContract != null, "No AA Factory deployed");
     const authServerPaymaster = await fixtures.deployExampleAuthServerPaymaster(
@@ -375,6 +377,8 @@ describe("SessionKeyModule tests", function () {
     );
     assert(authServerPaymaster != null, "No Auth Server Paymaster deployed");
 
+    logInfo(`SSO Account Address            : ${await ssoContract.getAddress()}`);
+    logInfo(`Beacon Address                 : ${await beaconContract.getAddress()}`);
     logInfo(`Session Address                : ${await sessionModuleContract.getAddress()}`);
     logInfo(`Passkey Address                : ${await verifierContract.getAddress()}`);
     logInfo(`Account Factory Address        : ${await factoryContract.getAddress()}`);
@@ -581,10 +585,10 @@ describe("SessionKeyModule tests", function () {
   });
 
   describe("Upgrade tests", function () {
-    let beacon: AAFactory;
+    let beacon: SsoBeacon;
 
     it("should check implementation address", async () => {
-      beacon = AAFactory__factory.connect(await fixtures.getAaFactoryAddress(), fixtures.wallet);
+      beacon = SsoBeacon__factory.connect(await fixtures.getBeaconAddress(), fixtures.wallet);
       expect(await beacon.implementation()).to.equal(await fixtures.getAccountImplAddress());
     });
 

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -602,10 +602,13 @@ describe("SessionKeyModule tests", function () {
       const proxy = new ethers.Contract(proxyAccountAddress, ["function dummy() pure returns (string)"], provider);
       expect(await proxy.dummy()).to.equal("dummy");
     });
+
+    it("should upgrade implementation back", async () => {
+      await beacon.upgradeTo(await fixtures.getAccountImplAddress());
+      expect(await beacon.implementation()).to.equal(await fixtures.getAccountImplAddress());
+    });
   });
 
   // TODO: module uninstall tests
-  // TODO: session expiresAt tests
   // TODO: session fee limit tests
-  // TODO: allowance tests
 });


### PR DESCRIPTION
# Description

Previously, `TransparentProxy` did not work with `AAFactory` due to it also being an `UpgradeableBeacon` which 
- set the owner and impl in the factory constructor, so proxy did not have those in storage
- had a bunch of overlapping methods between `TransparentProxy` and `UpgradeableBeacon`

This PR splits `AAFactory` and `UpgradeableBeacon` into 2 separate contracts