### PR TITLE
fix: multi validator account creation

### DIFF
--- a/src/validators/SessionKeyValidator.sol
+++ b/src/validators/SessionKeyValidator.sol
@@ -68,7 +68,7 @@ contract SessionKeyValidator is IValidationHook, IModuleValidator {
 
   function init(bytes calldata data) external {
     // to prevent duplicate inits, since this can be hook plus a validator
-    if (!_isHookAndModuleInitialized(msg.sender) && data.length != 0) {
+    if (_isHookAndModuleInitialized(msg.sender) && data.length != 0) {
       require(_addValidationKey(data), "init failed");
     }
   }


### PR DESCRIPTION
# Description
Fix the e2e tests in `zksync-sso` by only allowing to create a session after both the Hook and Module have been initalized