### PR TITLE
chore: add sepolia timestamp asserter address

### DIFF
--- a/src/helpers/TimestampAsserterLocator.sol
+++ b/src/helpers/TimestampAsserterLocator.sol
@@ -9,7 +9,7 @@ library TimestampAsserterLocator {
       return ITimestampAsserter(address(0x00000000000000000000000000000000808012));
     }
     if (block.chainid == 300) {
-      return ITimestampAsserter(address(0xa64ec71ee812ac62923c85cf0796aa58573c4cf3));
+      return ITimestampAsserter(address(0xa64EC71Ee812ac62923c85cf0796aA58573c4Cf3));
     }
     if (block.chainid == 324) {
       revert("Timestamp asserter is not deployed on ZKsync mainnet yet");

--- a/src/helpers/TimestampAsserterLocator.sol
+++ b/src/helpers/TimestampAsserterLocator.sol
@@ -9,7 +9,7 @@ library TimestampAsserterLocator {
       return ITimestampAsserter(address(0x00000000000000000000000000000000808012));
     }
     if (block.chainid == 300) {
-      revert("Timestamp asserter is not deployed on ZKsync Sepolia testnet yet");
+      return ITimestampAsserter(address(0xa64ec71ee812ac62923c85cf0796aa58573c4cf3));
     }
     if (block.chainid == 324) {
       revert("Timestamp asserter is not deployed on ZKsync mainnet yet");


### PR DESCRIPTION
# Description
Add Sepolia `TimestampAsserter` address. Here's the contract in block explorer: https://sepolia.explorer.zksync.io/address/0xa64EC71Ee812ac62923c85cf0796aA58573c4Cf3#contract

Here's also the validation that it's deployed to the Sepolia API server:
```sh
curl --request POST \
  --url https://sepolia.era.zksync.dev/ \
  --header 'Content-Type: application/json' \
  --data '{
      "jsonrpc": "2.0",
      "id": 1,
      "method": "zks_getTimestampAsserter",
      "params": []
    }'
```

Response:
```sh
{"jsonrpc":"2.0","result":"0xa64ec71ee812ac62923c85cf0796aa58573c4cf3","id":1}
```