### PR TITLE
Create2 helpers and example tests

### DIFF
--- a/src/AAFactory.sol
+++ b/src/AAFactory.sol
@@ -5,6 +5,7 @@ import { DEPLOYER_SYSTEM_CONTRACT, IContractDeployer } from "@matterlabs/zksync-
 import { SystemContractsCaller } from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
 
 import { ISsoAccount } from "./interfaces/ISsoAccount.sol";
+import { AccountProxy } from "./AccountProxy.sol";
 
 /// @title AAFactory
 /// @author Matter Labs
@@ -31,6 +32,18 @@ contract AAFactory {
     beacon = _beacon;
   }
 
+  function getBeaconProxyBytecodeHash() external view returns (bytes32) {
+    return beaconProxyBytecodeHash;
+  }
+
+  function getBeacon() external view returns (address) {
+    return beacon;
+  }
+
+  function getEncodedBeacon() external view returns (bytes memory) {
+    return abi.encode(beacon);
+  }
+
   /// @notice Deploys a new SSO account as a beacon proxy with the specified parameters.
   /// @dev Uses `create2` to deploy a proxy account, allowing for deterministic addresses based on the provided salt.
   /// @param _salt The salt used for the `create2` deployment to make the address deterministic.
@@ -46,6 +59,10 @@ contract AAFactory {
   ) external returns (address accountAddress) {
     require(accountMappings[_uniqueAccountId] == address(0), "Account already exists");
 
+    /*
+    AccountProxy beaconProxy = new AccountProxy{ salt: _salt }(beacon);
+    accountAddress = address(beaconProxy);
+    */
     (bool success, bytes memory returnData) = SystemContractsCaller.systemCallWithReturndata(
       uint32(gasleft()),
       address(DEPLOYER_SYSTEM_CONTRACT),

--- a/src/AAFactory.sol
+++ b/src/AAFactory.sol
@@ -5,7 +5,6 @@ import { DEPLOYER_SYSTEM_CONTRACT, IContractDeployer } from "@matterlabs/zksync-
 import { SystemContractsCaller } from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
 
 import { ISsoAccount } from "./interfaces/ISsoAccount.sol";
-import { AccountProxy } from "./AccountProxy.sol";
 
 /// @title AAFactory
 /// @author Matter Labs
@@ -59,10 +58,6 @@ contract AAFactory {
   ) external returns (address accountAddress) {
     require(accountMappings[_uniqueAccountId] == address(0), "Account already exists");
 
-    /*
-    AccountProxy beaconProxy = new AccountProxy{ salt: _salt }(beacon);
-    accountAddress = address(beaconProxy);
-    */
     (bool success, bytes memory returnData) = SystemContractsCaller.systemCallWithReturndata(
       uint32(gasleft()),
       address(DEPLOYER_SYSTEM_CONTRACT),

--- a/src/AAFactory.sol
+++ b/src/AAFactory.sol
@@ -17,8 +17,8 @@ contract AAFactory {
   event AccountCreated(address indexed accountAddress, string uniqueAccountId);
 
   /// @dev The bytecode hash of the beacon proxy, used for deploying proxy accounts.
-  bytes32 private immutable beaconProxyBytecodeHash;
-  address private immutable beacon;
+  bytes32 public immutable beaconProxyBytecodeHash;
+  address public immutable beacon;
 
   /// @notice A mapping from unique account IDs to their corresponding deployed account addresses.
   mapping(string => address) public accountMappings;
@@ -29,14 +29,6 @@ contract AAFactory {
   constructor(bytes32 _beaconProxyBytecodeHash, address _beacon) {
     beaconProxyBytecodeHash = _beaconProxyBytecodeHash;
     beacon = _beacon;
-  }
-
-  function getBeaconProxyBytecodeHash() external view returns (bytes32) {
-    return beaconProxyBytecodeHash;
-  }
-
-  function getBeacon() external view returns (address) {
-    return beacon;
   }
 
   function getEncodedBeacon() external view returns (bytes memory) {

--- a/test/BasicTest.ts
+++ b/test/BasicTest.ts
@@ -34,7 +34,7 @@ describe("Basic tests", function () {
     assert(accountImplContract != null, "No account impl deployed");
   });
 
-  it.only("should deploy proxy account via factory", async () => {
+  it("should deploy proxy account via factory", async () => {
     const aaFactoryContract = await fixtures.getAaFactory();
     assert(aaFactoryContract != null, "No AA Factory deployed");
 

--- a/test/BasicTest.ts
+++ b/test/BasicTest.ts
@@ -2,13 +2,11 @@ import { assert, expect } from "chai";
 import { ethers, parseEther, randomBytes } from "ethers";
 import { Wallet, ZeroAddress } from "ethers";
 import { it } from "mocha";
-import { ContractFactory, SmartAccount, utils } from "zksync-ethers";
+import { SmartAccount, utils } from "zksync-ethers";
 
 import { SsoAccount__factory } from "../typechain-types";
 import { CallStruct } from "../typechain-types/src/batch/BatchCaller";
-import { ContractFixtures, create2, ethersStaticSalt, getProvider } from "./utils";
-
-import * as hre from "hardhat";
+import { ContractFixtures, getProvider } from "./utils";
 
 describe("Basic tests", function () {
   const fixtures = new ContractFixtures();

--- a/test/BasicTest.ts
+++ b/test/BasicTest.ts
@@ -39,7 +39,7 @@ describe("Basic tests", function () {
     const factoryAddress = await aaFactoryContract.getAddress();
     expect(factoryAddress, "the factory address").to.equal(await fixtures.getAaFactoryAddress(), "factory address match");
 
-    const bytecodeHash = await aaFactoryContract.getBeaconProxyBytecodeHash();
+    const bytecodeHash = await aaFactoryContract.beaconProxyBytecodeHash();
     const deployedAccountContract = await fixtures.getAccountProxyContract();
     const deployedAccountContractCode = await deployedAccountContract.getDeployedCode();
     assert(deployedAccountContractCode != null, "No account code deployed");

--- a/test/BasicTest.ts
+++ b/test/BasicTest.ts
@@ -38,12 +38,10 @@ describe("Basic tests", function () {
     const aaFactoryContract = await fixtures.getAaFactory();
     assert(aaFactoryContract != null, "No AA Factory deployed");
     const factoryAddress = await aaFactoryContract.getAddress();
+    const bytecodeHash = await aaFactoryContract.getBeaconProxyBytecodeHash();
+    const args = await aaFactoryContract.getEncodedBeacon();
     console.log("factoryAddress", factoryAddress);
-
-    const accountProxy = await hre.artifacts.readArtifact("AccountProxy");
-    const beaconContract = await fixtures.getAccountProxyContract();
-    const bytecodeHash = utils.hashBytecode(accountProxy.bytecode);
-    const args = beaconContract.interface.encodeDeploy([await beaconContract.getAddress()])
+    
     const standardCreate2Address = utils.create2Address(factoryAddress, bytecodeHash, ethersStaticSalt, args) ;
     console.log("standardCreate2Address ", standardCreate2Address);
     // standardCreate2Address should be: "0x7dd7a774a1CBCe9Fa8Ab8A639262aBde60C20FC9"

--- a/test/BasicTest.ts
+++ b/test/BasicTest.ts
@@ -6,7 +6,7 @@ import { ContractFactory, SmartAccount, utils } from "zksync-ethers";
 
 import { SsoAccount__factory } from "../typechain-types";
 import { CallStruct } from "../typechain-types/src/batch/BatchCaller";
-import { ContractFixtures, create2, getProvider } from "./utils";
+import { ContractFixtures, create2, ethersStaticSalt, getProvider } from "./utils";
 
 import * as hre from "hardhat";
 
@@ -35,7 +35,7 @@ describe.only("Basic tests", function () {
   });
 
   it.only("should deploy proxy account via factory", async () => {
-    const aaFactoryContract = await fixtures.getAaFactory(fixtures.ethersStaticSalt);
+    const aaFactoryContract = await fixtures.getAaFactory(ethersStaticSalt);
     assert(aaFactoryContract != null, "No AA Factory deployed");
     const factoryAddress = await aaFactoryContract.getAddress();
     console.log("factoryAddress", factoryAddress);
@@ -46,7 +46,8 @@ describe.only("Basic tests", function () {
     const bytecodeHash = utils.hashBytecode(contractArtifact.bytecode);
     const standardCreate2Address = utils.create2Address(implAddress, bytecodeHash, salt, "0x");
     console.log("standardCreate2Address ", standardCreate2Address);
-    // should be: "0xBDBf2429373eF08c773CFd74B2Af6fE154414de8"
+    // standardCreate2Address should be: "0x7dd7a774a1CBCe9Fa8Ab8A639262aBde60C20FC9"
+    // but the create2address thinks it should be: "0xABE9055866F575Ad8DF70d473EDb385c1deD62fC"
     const accountCode = await fixtures.wallet.provider.getCode(standardCreate2Address);
 
     const deployTx = await aaFactoryContract.deployProxySsoAccount(


### PR DESCRIPTION
# Description

Create2 is very specific about what it uses to hash, so getting those exactly from the factory makes doing counterfactual deployments so much easier!

Making the factory deploy using create2 in the tests also helps with run-to-run address comparisons, as it's how everything else is deployed in the tests!

## Additional context

There are like 3 tricks to getting this correct that's worth the test cases to show where the data comes from and how to format it in the same way that solidity does.

1. Now that we have 2 proxies involved in account deployment, picking the correct contract that's getting deployed can be tricky! (AccountProxy is getting deployed, while SsoBeacon is what's getting provided to that proxy)
2. Now that the factory has a proxy, we also need to make sure we're picking that address correctly (it's the factory not the beacon!)
3. The address encoding is done because it's encoding a call to the deployer, so we can't just use the full-length address.