### PR TITLE
feat: use static salt for deploy task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-    # Start era test node (alpha.34)
-    - name: Anvil ZKsync Action
-      uses: dutterbutter/era-test-node-action@298eea49e29e226baa04195b1d0fce7042439259
+    # Start era test node
+    - name: Pre-Anvil ZKsync Action
+      uses: dutterbutter/era-test-node-action@66121581304ee2d4f0c1c2de46a3d08f1c2f5264
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZKsync SSO
+# ZKsync SSO Clave Contracts
 
 [![License](https://img.shields.io/badge/license-GPL3-blue)](LICENSE)
 [![CI](https://github.com/matter-labs/zksync-account-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/matter-labs/zksync-account-sdk/actions/workflows/ci.yml)
@@ -12,19 +12,13 @@ Forked from [Clave](https://github.com/getclave/clave-contracts).
 
 <!-- prettier-ignore -->
 > [!CAUTION]
-> ZKsync SSO is under active development and is not yet feature
-> complete. Use it to improve your development applications and tooling. Please
-> do not use it in production environments.
+> The factory and module interfaces are not yet stable! Any modules created
+> against the IModuleValidator interface will likely need to be updated in the
+> final version. The code is currently under audit and the latest may contain
+> security vulnerabilities.
 
-- 🧩 Modular smart accounts based on
-  [ERC-7579](https://eips.ethereum.org/EIPS/eip-7579#modules)
-- 🔑 Passkey authentication (no seed phrases)
-- ⏰ Sessions w/ easy configuration and management
-- 💰 Integrated paymaster support
-- ❤️‍🩹 Account recovery _(Coming Soon)_
-- 💻 Simple SDKs : JavaScript, iOS/Android _(Coming Soon)_
-- 🤝 Open-source authentication server
-- 🎓 Examples to get started quickly
+See the [ZKsync SSO](https://github.com/matter-labs/zksync-sso) project for a
+complete developer solution, this project is just the smart contract components.
 
 ## Local Development
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -17,7 +17,7 @@ async function deploy(name: string, deployer: Wallet, proxy: boolean, args?: any
   console.log("Deploying", name, "contract...");
   let implContract;
   if (name == FACTORY_NAME) {
-    implContract = await deployFactory(deployer, args![0]);
+    implContract = await deployFactory(deployer, args![0], ethersStaticSalt);
   } else {
     implContract = await create2(name, deployer, ethersStaticSalt, args);
   }

--- a/src/AAFactory.sol
+++ b/src/AAFactory.sol
@@ -17,8 +17,8 @@ contract AAFactory {
   event AccountCreated(address indexed accountAddress, string uniqueAccountId);
 
   /// @dev The bytecode hash of the beacon proxy, used for deploying proxy accounts.
-  bytes32 private immutable beaconProxyBytecodeHash;
-  address private immutable beacon;
+  bytes32 public immutable beaconProxyBytecodeHash;
+  address public immutable beacon;
 
   /// @notice A mapping from unique account IDs to their corresponding deployed account addresses.
   mapping(string => address) public accountMappings;
@@ -29,6 +29,10 @@ contract AAFactory {
   constructor(bytes32 _beaconProxyBytecodeHash, address _beacon) {
     beaconProxyBytecodeHash = _beaconProxyBytecodeHash;
     beacon = _beacon;
+  }
+
+  function getEncodedBeacon() external view returns (bytes memory) {
+    return abi.encode(beacon);
   }
 
   /// @notice Deploys a new SSO account as a beacon proxy with the specified parameters.

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -166,10 +166,9 @@ export async function deployFactory(wallet: Wallet, beaconAddress: string, salt?
   const standardCreate2Address = utils.create2Address(wallet.address, factoryBytecodeHash, factorySalt, constructorArgs);
   const accountCode = await wallet.provider.getCode(standardCreate2Address);
   if (accountCode != "0x") {
-    logInfo(`Factory already exists!`);
+    logInfo(`Factory already exists at ${standardCreate2Address}`);
     return AAFactory__factory.connect(standardCreate2Address, wallet);
   }
-  logInfo(`Factory doesn't exist at ${standardCreate2Address}!`);
   const factory = await deployer.deploy(
     bytecodeHash,
     beaconAddress,


### PR DESCRIPTION

# Description

This is so helpful when testing locally, but carries a little risk that the code is easily front-runnable for ownership

## Additional context

Testing the extension is easier when I get the same addresses even after restarting the test node or redeploying unchanged code