### PR TITLE
Correct deploy Property Name and Align Object Formatting

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,7 @@ import { HardhatUserConfig } from "hardhat/config";
 const config: HardhatUserConfig = {
   paths: {
     sources: "src",
-    deployPaths: "scripts",
+    deploy: "scripts",
   },
   defaultNetwork: "inMemoryNode",
   networks: {
@@ -56,7 +56,7 @@ const config: HardhatUserConfig = {
     version: "0.8.28",
     settings: {
       evmVersion: "cancun",
-    }
+    },
   },
 };
 


### PR DESCRIPTION
### 1. Replacing deployPaths with deploy:
- deployPaths: "scripts",
+ deploy: "scripts",

**Rationale: This is the correct property according to zkSync Hardhat specification. deployPaths was an incorrect property name, while deploy is the proper name for specifying the directory containing deployment scripts.**

### 2. Formatting of the closing bracket in settings:
- }
+ },
**Rationale: Added a comma after the closing bracket to maintain consistent formatting in TypeScript/JavaScript objects. This is important for maintaining uniform code style and preventing potential errors when adding new properties.**