### PR TITLE
fix: paymaster check in validateFeeLimit

### DIFF
--- a/src/libraries/SessionLib.sol
+++ b/src/libraries/SessionLib.sol
@@ -179,8 +179,8 @@ library SessionLib {
     // most of the computation needed to validate the session.
 
     // TODO: update fee allowance with the gasleft/refund at the end of execution
-    if (transaction.paymaster != 0) {
-      // If a paymaster is paying the fee, we don't need to check the fee limit
+    // If a paymaster is paying the fee, we don't need to check the fee limit
+    if (transaction.paymaster == 0) {
       uint256 fee = transaction.maxFeePerGas * transaction.gasLimit;
       spec.feeLimit.checkAndUpdate(state.fee, fee, periodId);
     }


### PR DESCRIPTION
# Description

The check for if the transaction is using a paymaster was incorrect. It checked for the opposite.

## Additional context

Will add fee-limit check tests (including ones using a paymaster) in a follow-up PR