### PR TITLE
chore: update duplicate ierc165 check

### DIFF
--- a/src/validators/SessionKeyValidator.sol
+++ b/src/validators/SessionKeyValidator.sol
@@ -38,7 +38,7 @@ contract SessionKeyValidator is IModuleValidator {
   }
 
   // This module should not be used to validate signatures
-  function validateSignature(bytes32 signedHash, bytes memory signature) external pure returns (bool) {
+  function validateSignature(bytes32, bytes memory) external pure returns (bool) {
     return false;
   }
 
@@ -80,10 +80,8 @@ contract SessionKeyValidator is IModuleValidator {
     }
   }
 
-  function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
-    return
-      interfaceId != 0xffffffff &&
-      (interfaceId == type(IERC165).interfaceId || interfaceId == type(IModuleValidator).interfaceId);
+  function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
+    return interfaceId == type(IERC165).interfaceId || interfaceId == type(IModuleValidator).interfaceId;
   }
 
   // TODO: make the session owner able revoke its own key, in case it was leaked, to prevent further misuse?
@@ -111,10 +109,10 @@ contract SessionKeyValidator is IModuleValidator {
 
   function validateTransaction(
     bytes32 signedHash,
-    bytes memory _signature,
+    bytes memory,
     Transaction calldata transaction
   ) external returns (bool) {
-    (bytes memory transactionSignature, address validator, bytes memory validatorData) = SignatureDecoder
+    (bytes memory transactionSignature, address _validator, bytes memory validatorData) = SignatureDecoder
       .decodeSignature(transaction.signature);
     (SessionLib.SessionSpec memory spec, uint64[] memory periodIds) = abi.decode(
       validatorData, // this is passed by the signature builder

--- a/src/validators/WebAuthValidator.sol
+++ b/src/validators/WebAuthValidator.sol
@@ -9,7 +9,6 @@ import { VerifierCaller } from "../helpers/VerifierCaller.sol";
 import { JsmnSolLib } from "../libraries/JsmnSolLib.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Base64 } from "solady/src/utils/Base64.sol";
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /// @title AAFactory
 /// @author Matter Labs
@@ -60,7 +59,7 @@ contract WebAuthValidator is VerifierCaller, IModuleValidator {
   function validateTransaction(
     bytes32 signedHash,
     bytes memory signature,
-    Transaction calldata _transaction
+    Transaction calldata
   ) external view returns (bool) {
     return webAuthVerify(signedHash, signature);
   }
@@ -153,7 +152,7 @@ contract WebAuthValidator is VerifierCaller, IModuleValidator {
     valid = callVerifier(P256_VERIFIER, message, rs, pubKey);
   }
 
-  function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+  function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
     return interfaceId == type(IERC165).interfaceId || interfaceId == type(IModuleValidator).interfaceId;
   }
 


### PR DESCRIPTION
# Description

The caller is specified to check the invalid interface id instead of the supports interface function.


## Additional context

Also remove some unused variable names