### PR TITLE
chore: add SPDX to IModule.sol

### DIFF
--- a/src/interfaces/IModule.sol
+++ b/src/interfaces/IModule.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /**
  * @title Module interface
  * @dev Interface for a module that can be added to SSO account (e.g. hook or validator).


### PR DESCRIPTION
# Description

The IModule.sol file is lacking an SPDX license identifier.

To avoid legal issues regarding copyright and follow best practices, consider adding SPDX license identifiers to files as suggested by the Solidity documentation.

## Additional context

From N-05