### PR TITLE
feat: Slither pipeline integration

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,56 @@
+name: Slither scanner
+
+on: pull_request
+
+jobs:
+  slither:
+    name: Slither check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.11.0
+
+      - name: Use Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: lts/Iron
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install -r --frozen-lockfile
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+
+      - name: Install foundry-zksync
+        run: |
+          mkdir ./foundry-zksync
+          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz
+          tar zxf foundry_nightly_linux_amd64.tar.gz -C ./foundry-zksync
+          chmod +x ./foundry-zksync/forge ./foundry-zksync/cast
+          echo "$PWD/foundry-zksync" >> $GITHUB_PATH
+
+      - name: Foundry config file
+        run: |
+          echo "[profile.default]" > foundry.toml
+          echo "optimizer = true" >> foundry.toml
+          echo "optimizer_runs = 20_000" >> foundry.toml
+          echo "via_ir = true" >> foundry.toml
+          echo "" >> foundry.toml
+
+      - name: Install Slither
+        run: |
+          pip install slither-analyzer
+
+      - name: Run Slither
+        working-directory: ./
+        run: |
+          slither --config ./slither.config.json .

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,12 @@
+{
+  "filter_paths": "(test|src/test|scripts|node_modules)",
+  "detectors_to_exclude": "uninitialized-local",
+  "exclude_dependencies": true,
+  "compile_force_framework": "foundry",
+  "foundry_ignore_compile": false,
+  "exclude_high": false,
+  "exclude_medium": false,
+  "exclude_low": true,
+  "exclude_informational": true,
+  "exclude_optimization": true
+}

--- a/src/AAFactory.sol
+++ b/src/AAFactory.sol
@@ -63,10 +63,10 @@ contract AAFactory {
     require(success, "Deployment failed");
     (accountAddress) = abi.decode(returnData, (address));
 
+    accountMappings[_uniqueAccountId] = accountAddress;
+
     // Initialize the newly deployed account with validators, hooks and K1 owners.
     ISsoAccount(accountAddress).initialize(_initialValidators, _initialK1Owners);
-
-    accountMappings[_uniqueAccountId] = accountAddress;
 
     emit AccountCreated(accountAddress, _uniqueAccountId);
   }

--- a/src/SsoAccount.sol
+++ b/src/SsoAccount.sol
@@ -213,6 +213,8 @@ contract SsoAccount is Initializable, HookManager, ERC1271Handler, TokenCallback
   /// @dev Reverts if the Nonce Holder stores different `_nonce` value from the expected one.
   /// @param _expectedNonce The nonce value expected for the account to be stored in the Nonce Holder.
   function _incrementNonce(uint256 _expectedNonce) internal {
+    // Allow-listing slither finding as the call's success is checked+revert within the fn
+    // slither-disable-next-line unused-return
     SystemContractsCaller.systemCallWithPropagatedRevert(
       uint32(gasleft()),
       address(NONCE_HOLDER_SYSTEM_CONTRACT),

--- a/src/managers/HookManager.sol
+++ b/src/managers/HookManager.sol
@@ -40,10 +40,9 @@ abstract contract HookManager is IHookManager, Auth {
   /// @inheritdoc IHookManager
   function unlinkHook(address hook, bool isValidation, bytes calldata deinitData) external onlySelf {
     _removeHook(hook, isValidation);
-    // Allow-listing slither finding as the call's success is checked below
+    // Allow-listing slither finding as we don´t want reverting calls to prevent unlinking
     // slither-disable-next-line unused-return
-    (bool success, ) = hook.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
-    require(success, "onUninstall call failed");
+    hook.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
   }
 
   /// @inheritdoc IHookManager

--- a/src/managers/HookManager.sol
+++ b/src/managers/HookManager.sol
@@ -40,7 +40,10 @@ abstract contract HookManager is IHookManager, Auth {
   /// @inheritdoc IHookManager
   function unlinkHook(address hook, bool isValidation, bytes calldata deinitData) external onlySelf {
     _removeHook(hook, isValidation);
-    hook.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
+    // Allow-listing slither finding as the call's success is checked below
+    // slither-disable-next-line unused-return
+    (bool success, ) = hook.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
+    require(success, "onUninstall call failed");
   }
 
   /// @inheritdoc IHookManager

--- a/src/managers/ValidatorManager.sol
+++ b/src/managers/ValidatorManager.sol
@@ -39,7 +39,10 @@ abstract contract ValidatorManager is IValidatorManager, Auth {
   ///@inheritdoc IValidatorManager
   function unlinkModuleValidator(address validator, bytes calldata deinitData) external onlySelf {
     _removeModuleValidator(validator);
-    validator.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
+    // Allow-listing slither finding as the call's success is checked below
+    // slither-disable-next-line unused-return
+    (bool success, ) = validator.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
+    require(success, "onUninstall call failed");
   }
 
   /// @inheritdoc IValidatorManager

--- a/src/managers/ValidatorManager.sol
+++ b/src/managers/ValidatorManager.sol
@@ -39,7 +39,7 @@ abstract contract ValidatorManager is IValidatorManager, Auth {
   ///@inheritdoc IValidatorManager
   function unlinkModuleValidator(address validator, bytes calldata deinitData) external onlySelf {
     _removeModuleValidator(validator);
-    // Allow-listing slither finding as we don´t want reverting modules to lock unlinking
+    // Allow-listing slither finding as we don´t want reverting calls to prevent unlinking
     // slither-disable-next-line unused-return
     validator.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
   }

--- a/src/managers/ValidatorManager.sol
+++ b/src/managers/ValidatorManager.sol
@@ -39,10 +39,9 @@ abstract contract ValidatorManager is IValidatorManager, Auth {
   ///@inheritdoc IValidatorManager
   function unlinkModuleValidator(address validator, bytes calldata deinitData) external onlySelf {
     _removeModuleValidator(validator);
-    // Allow-listing slither finding as the call's success is checked below
+    // Allow-listing slither finding as we don´t want reverting modules to lock unlinking
     // slither-disable-next-line unused-return
-    (bool success, ) = validator.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
-    require(success, "onUninstall call failed");
+    validator.excessivelySafeCall(gasleft(), 0, abi.encodeCall(IModule.onUninstall, (deinitData)));
   }
 
   /// @inheritdoc IValidatorManager


### PR DESCRIPTION
# Description

Addition of the Slither static analyzer to the pipeline of the repo. Highlights of the current configuration:
- Runs on PRs.
- Only checks for medium or high-risk findings.
- There is onesilenced detectors ["uninitialized local variables"](https://github.com/crytic/slither/wiki/Detector-Documentation#uninitialized-local-variables).
- It uses `foundry` for compilation instead of `pnpm`, creating the `foundry.toml` file as part of the GH action.
  - I have tried compiling it through our recommended steps and then running slither afterward, but it always ends up erroring... Ideally, this should replicate the exact tool chain we used so this remains as a TODO

In addition, some contracts were slightly modified to fully comply with the findings or to silence the unnecessary ones.

## Additional context
