### PR TITLE
[Draft] fix: audit N-09 and N-12

### DIFF
--- a/src/AAFactory.sol
+++ b/src/AAFactory.sol
@@ -65,7 +65,7 @@ contract AAFactory {
 
     accountMappings[_uniqueAccountId] = accountAddress;
 
-    // Initialize the newly deployed account with validators, hooks and K1 owners.
+    // Initialize the newly deployed account with validators and K1 owners.
     ISsoAccount(accountAddress).initialize(_initialValidators, _initialK1Owners);
 
     emit AccountCreated(accountAddress, _uniqueAccountId);

--- a/src/interfaces/IHook.sol
+++ b/src/interfaces/IHook.sol
@@ -6,7 +6,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 import { IModule } from "./IModule.sol";
 
 /// @title Validation hook interface for native AA
-/// @author getclave.io
+/// @author Based on https://getclave.io, modified version by Matter Labs
 /// @notice Validation hooks trigger before each transaction,
 /// can be used to enforce additional restrictions on the account and/or transaction during the validation phase.
 interface IValidationHook is IModule, IERC165 {
@@ -18,7 +18,7 @@ interface IValidationHook is IModule, IERC165 {
 }
 
 /// @title Execution hook interface for native AA
-/// @author getclave.io
+/// @author Based on https://getclave.io, modified version by Matter Labs
 /// @notice Execution hooks trigger before and after each transaction, during the execution phase.
 interface IExecutionHook is IModule, IERC165 {
   /// @notice Hook that triggers before each transaction during the execution phase.

--- a/src/managers/HookManager.sol
+++ b/src/managers/HookManager.sol
@@ -16,7 +16,7 @@ import { IModule } from "../interfaces/IModule.sol";
 /**
  * @title Manager contract for hooks
  * @notice Abstract contract for managing the enabled hooks of the account
- * @dev Hook addresses are stored in a linked list
+ * @dev Hook addresses are stored in an EnumerableSet
  * @author https://getclave.io
  */
 abstract contract HookManager is IHookManager, Auth {

--- a/src/managers/HookManager.sol
+++ b/src/managers/HookManager.sol
@@ -17,7 +17,7 @@ import { IModule } from "../interfaces/IModule.sol";
  * @title Manager contract for hooks
  * @notice Abstract contract for managing the enabled hooks of the account
  * @dev Hook addresses are stored in an EnumerableSet
- * @author https://getclave.io
+ * @author Based on https://getclave.io, modified version by Matter Labs
  */
 abstract contract HookManager is IHookManager, Auth {
   using EnumerableSet for EnumerableSet.AddressSet;

--- a/src/managers/OwnerManager.sol
+++ b/src/managers/OwnerManager.sol
@@ -11,7 +11,7 @@ import { IOwnerManager } from "../interfaces/IOwnerManager.sol";
  * @title Manager contract for owners
  * @notice Abstract contract for managing the owners of the account
  * @dev K1 Owners are secp256k1 addresses
- * @dev Owners are stored in a linked list
+ * @dev Owners are stored in an EnumerableSet
  * @author https://getclave.io
  */
 abstract contract OwnerManager is IOwnerManager, Auth {


### PR DESCRIPTION
# Description

Fix for the OZ audit issue N-09 "Misleading Documentation". Pending first bulletpoint:
- The docstrings of the [k1AddOwner](https://github.com/matter-labs/zksync-sso-clave-contracts/blob/fc0af3442594ad2dc343dbb2b918e478251bc293/src/interfaces/IOwnerManager.sol#L23) and [k1RemoveOwner](https://github.com/matter-labs/zksync-sso-clave-contracts/blob/fc0af3442594ad2dc343dbb2b918e478251bc293/src/interfaces/IOwnerManager.sol#L31) functions from the IOwnerManager interface imply that the functions can be called by whitelisted modules, which is not the case.

Fix for the OZ audit issue N-12 "Modified Contracts Still Point to Clave as the Author".

## Additional context
