### PR TITLE
fix: exec hooks behaviour when adding/removing

### DIFF
--- a/src/managers/HookManager.sol
+++ b/src/managers/HookManager.sol
@@ -77,24 +77,25 @@ abstract contract HookManager is IHookManager, SelfAuth {
 
   // Runs the execution hooks that are enabled by the account before and after _executeTransaction
   modifier runExecutionHooks(Transaction calldata transaction) {
-    EnumerableSet.AddressSet storage hookList = _executionHooks();
-    uint256 totalHooks = hookList.length();
+    address[] memory hookList = _executionHooks().values();
+    uint256 totalHooks = hookList.length;
     bytes[] memory context = new bytes[](totalHooks);
 
     for (uint256 i = 0; i < totalHooks; i++) {
-      context[i] = IExecutionHook(hookList.at(i)).preExecutionHook(transaction);
+      context[i] = IExecutionHook(hookList[i]).preExecutionHook(transaction);
     }
 
     _;
 
-    // If we removed any hooks, we have to update totalHooks.
+    // If we removed any hooks, we have to update hookList.
     // If we added any hooks, we don't want them to run yet.
-    if (totalHooks > hookList.length()) {
-      totalHooks = hookList.length();
+    if (totalHooks > _executionHooks().length()) {
+      hookList = _executionHooks().values();
+      totalHooks = hookList.length;
     }
 
     for (uint256 i = 0; i < totalHooks; i++) {
-      IExecutionHook(hookList.at(i)).postExecutionHook(context[i]);
+      IExecutionHook(hookList[i]).postExecutionHook(context[i]);
     }
   }
 

--- a/src/managers/HookManager.sol
+++ b/src/managers/HookManager.sol
@@ -87,15 +87,14 @@ abstract contract HookManager is IHookManager, SelfAuth {
 
     _;
 
-    // If we removed any hooks, we have to update hookList.
-    // If we added any hooks, we don't want them to run yet.
-    if (totalHooks > _executionHooks().length()) {
-      hookList = _executionHooks().values();
-      totalHooks = hookList.length;
-    }
+    EnumerableSet.AddressSet storage newHookList = _executionHooks();
 
     for (uint256 i = 0; i < totalHooks; i++) {
-      IExecutionHook(hookList[i]).postExecutionHook(context[i]);
+      // Only execute hooks which are both in the old `hookList` and the `newHookList`,
+      // and we don't want to execute hooks that were removed and/or added during this transaction.
+      if (newHookList.contains(hookList[i])) {
+        IExecutionHook(hookList[i]).postExecutionHook(context[i]);
+      }
     }
   }
 


### PR DESCRIPTION
# Description

- lock order of pre- and post- exec hooks within a transaction
- don't execute hooks which have been removed and/or added in current transaction