### PR TITLE
chore: double check validate transaction arguments

### DIFF
--- a/src/validators/SessionKeyValidator.sol
+++ b/src/validators/SessionKeyValidator.sol
@@ -139,11 +139,14 @@ contract SessionKeyValidator is IModuleValidator {
   /// @dev Session spec and period IDs must be provided as validator data
   function validateTransaction(
     bytes32 signedHash,
-    bytes calldata,
+    bytes calldata providedTransactionSignature,
     Transaction calldata transaction
   ) external returns (bool) {
     (bytes memory transactionSignature, address _validator, bytes memory validatorData) = SignatureDecoder
       .decodeSignature(transaction.signature);
+    if (keccak256(providedTransactionSignature) != keccak256(transactionSignature)) {
+      return false;
+    }
     (SessionLib.SessionSpec memory spec, uint64[] memory periodIds) = abi.decode(
       validatorData, // this is passed by the signature builder
       (SessionLib.SessionSpec, uint64[])


### PR DESCRIPTION
# Description

This is basically double checking the bootloader.
The Session key validator does this as well (without the comparison to validate), so this change makes it consistent.

## Additional context

The auditors mentioned the use of the signature was inconsistent between the two modules. Maybe it's better to change the interface so we don't provide duplicate data by not providing the parsed signature?

It was nice that the signature comes pre-parsed, but it's also a little harder to trust and for the session key validation the hook data would need an extra decode?