### PR TITLE
Fix/paymaster-recovery-validator

### DIFF
--- a/src/test/ExampleAuthServerPaymaster.sol
+++ b/src/test/ExampleAuthServerPaymaster.sol
@@ -22,8 +22,10 @@ contract ExampleAuthServerPaymaster is IPaymaster, Ownable {
   bytes4 constant SESSION_CREATE_SELECTOR = SessionKeyValidator.createSession.selector;
   bytes4 constant SESSION_REVOKE_KEY_SELECTOR = SessionKeyValidator.revokeKey.selector;
   bytes4 constant SESSION_REVOKE_KEYS_SELECTOR = SessionKeyValidator.revokeKeys.selector;
-  bytes4 constant ACCOUNT_RECOVERY_ADD_KEY_SELECTOR = GuardianRecoveryValidator.addValidationKey.selector;
-  bytes4 constant ACCOUNT_RECOVERY_PROPOSE_KEY_SELECTOR = GuardianRecoveryValidator.proposeValidationKey.selector;
+  bytes4 constant GUARDIAN_RECOVERY_ADD_KEY_SELECTOR = GuardianRecoveryValidator.addValidationKey.selector;
+  bytes4 constant GUARDIAN_RECOVERY_PROPOSE_KEY_SELECTOR = GuardianRecoveryValidator.proposeValidationKey.selector;
+  bytes4 constant GUARDIAN_RECOVERY_DISCARD_RECOVERY_SELECTOR = GuardianRecoveryValidator.discardRecovery.selector;
+  bytes4 constant GUARDIAN_RECOVERY_REMOVE_KEY_SELECTOR = GuardianRecoveryValidator.removeValidationKey.selector;
 
   modifier onlyBootloader() {
     require(msg.sender == BOOTLOADER_FORMAL_ADDRESS, "Only bootloader can call this method");
@@ -69,9 +71,13 @@ contract ExampleAuthServerPaymaster is IPaymaster, Ownable {
         "Unsupported method"
       );
     }
-    if (to == SESSION_KEY_VALIDATOR_CONTRACT_ADDRESS) {
+
+    if (to == ACCOUNT_RECOVERY_VALIDATOR_CONTRACT_ADDRESS) {
       require(
-        methodSelector == ACCOUNT_RECOVERY_ADD_KEY_SELECTOR || methodSelector == ACCOUNT_RECOVERY_PROPOSE_KEY_SELECTOR,
+        methodSelector == GUARDIAN_RECOVERY_ADD_KEY_SELECTOR ||
+          methodSelector == GUARDIAN_RECOVERY_PROPOSE_KEY_SELECTOR ||
+          methodSelector == GUARDIAN_RECOVERY_DISCARD_RECOVERY_SELECTOR ||
+          methodSelector == GUARDIAN_RECOVERY_REMOVE_KEY_SELECTOR,
         "Unsupported method"
       );
     }

--- a/src/validators/GuardianRecoveryValidator.sol
+++ b/src/validators/GuardianRecoveryValidator.sol
@@ -24,6 +24,7 @@ contract GuardianRecoveryValidator is Initializable, IGuardianRecoveryValidator 
     string accountId;
   }
 
+  error GuardianCannotBeSelf();
   error GuardianNotFound(address guardian);
   error GuardianNotProposed(address guardian);
   error PasskeyNotMatched();
@@ -85,6 +86,8 @@ contract GuardianRecoveryValidator is Initializable, IGuardianRecoveryValidator 
   ///   2. Enable `addValidationKey` to confirm this account
   /// @param newGuardian New Guardian's address
   function proposeValidationKey(address newGuardian) external {
+    if (msg.sender == newGuardian) revert GuardianCannotBeSelf();
+
     Guardian[] storage guardians = accountGuardians[msg.sender];
 
     // If the guardian exist this method stops
@@ -134,7 +137,6 @@ contract GuardianRecoveryValidator is Initializable, IGuardianRecoveryValidator 
   /// @param key Encoded address of account which msg.sender is becoming guardian of
   /// @return Flag indicating whether guardian was already valid or not
   function addValidationKey(bytes memory key) external returns (bool) {
-    // Interprets argument as address;
     address accountToGuard = abi.decode(key, (address));
     Guardian[] storage guardians = accountGuardians[accountToGuard];
 


### PR DESCRIPTION
# Description
- Add missing functions from guardian recovery validator to paymaster
- Add check to validate guardian is not self


## Additional context
