### PR TITLE
benchmark: OidcKeyRegistry with and without merkle tree calculation

### DIFF
--- a/src/OidcKeyRegistryNoMerkleComputation.sol
+++ b/src/OidcKeyRegistryNoMerkleComputation.sol
@@ -39,13 +39,14 @@ contract OidcKeyRegistryNoMerkleComputation is Initializable, OwnableUpgradeable
   }
 
   function addKeys(Key[] memory newKeys, bytes32 root) public onlyOwner {
+    uint8 nextIndex = keyIndex;
     for (uint8 i = 0; i < newKeys.length; i++) {
-      uint8 nextIndex = (keyIndex + 1 + i) % MAX_KEYS; // Circular buffer
+      nextIndex = (keyIndex + 1 + i) % MAX_KEYS; // Circular buffer
       OIDCKeys[nextIndex] = newKeys[i];
     }
 
     merkleRoot = root;
-    keyIndex = uint8((uint256(keyIndex) + newKeys.length) % uint256(MAX_KEYS));
+    keyIndex = nextIndex;
   }
 
   function getKey(bytes32 issHash, bytes32 kid) public view returns (Key memory) {

--- a/src/OidcKeyRegistryNoMerkleComputation.sol
+++ b/src/OidcKeyRegistryNoMerkleComputation.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+contract OidcKeyRegistryNoMerkleComputation is Initializable, OwnableUpgradeable {
+  uint8 public constant MAX_KEYS = 8;
+  bytes32 public merkleRoot; // Merkle root should be on slot 1
+
+  struct Key {
+    bytes32 issHash; // Issuer
+    bytes32 kid; // Key ID
+    bytes n; // RSA modulus
+    bytes e; // RSA exponent
+  }
+
+  Key[MAX_KEYS] public OIDCKeys;
+  uint8 public keyIndex;
+
+  constructor() {
+    initialize();
+  }
+
+  function initialize() public initializer {
+    __Ownable_init();
+    keyIndex = MAX_KEYS - 1;
+  }
+
+  function hashIssuer(string memory iss) public pure returns (bytes32) {
+    return keccak256(abi.encodePacked(iss));
+  }
+
+  function addKey(Key memory newKey, bytes32 root) public onlyOwner {
+    Key[] memory newKeys = new Key[](1);
+    newKeys[0] = newKey;
+    addKeys(newKeys, root);
+  }
+
+  function addKeys(Key[] memory newKeys, bytes32 root) public onlyOwner {
+    for (uint8 i = 0; i < newKeys.length; i++) {
+      uint8 nextIndex = (keyIndex + 1 + i) % MAX_KEYS; // Circular buffer
+      OIDCKeys[nextIndex] = newKeys[i];
+    }
+
+    merkleRoot = root;
+    keyIndex = uint8((uint256(keyIndex) + newKeys.length) % uint256(MAX_KEYS));
+  }
+
+  function getKey(bytes32 issHash, bytes32 kid) public view returns (Key memory) {
+    require(issHash != 0, "Invalid issHash");
+    require(kid != 0, "Invalid kid");
+    for (uint8 i = 0; i < MAX_KEYS; i++) {
+      if (OIDCKeys[i].issHash == issHash && OIDCKeys[i].kid == kid) {
+        return OIDCKeys[i];
+      }
+    }
+    revert("Key not found");
+  }
+
+  function verifyKey(Key memory key, bytes32[] memory proof) public view returns (bool) {
+    bytes32 leaf = _hashKey(key);
+    return MerkleProof.verify(proof, merkleRoot, leaf);
+  }
+
+  function _hashKey(Key memory key) private pure returns (bytes32) {
+    return keccak256(bytes.concat(keccak256(abi.encode(key.issHash, key.kid, key.n, key.e))));
+  }
+}


### PR DESCRIPTION
# Description
Added the `OidcKeyRegistry` contract, which removes the Merkle tree calculation.  
Compared gas usage between the original and new contract when calling `addKey`:

- With Merkle tree calculation: **294,930 gas**  
  [Transaction Link](https://sepolia.explorer.zksync.io/tx/0x2cbb206dcebd82cba213f912aac02c2e3d94a1c7c9b0e08ef331cb2bc6da3afe)  

- Without Merkle tree calculation: **199,266 gas**  
  [Transaction Link](https://sepolia.explorer.zksync.io/tx/0x7ff581fcb8713d09d01b078d8cc958778504c4142fa92263c13d840d18b2c1f6)  

**Gas Reduction**  
The new implementation reduces gas costs by **~33%**, resulting in a **~$0.006** fee reduction.  
However, I believe this cost is worth paying for the extra verification and transparency provided by the Merkle tree calculation.



