### PR TITLE
L-01 Duplicate kid Values in OidcKeyRegistry Allow for Partial Key Deletion and Retrieval

### DIFF
--- a/src/OidcKeyRegistry.sol
+++ b/src/OidcKeyRegistry.sol
@@ -96,11 +96,20 @@ contract OidcKeyRegistry is IOidcKeyRegistry, Initializable, OwnableUpgradeable 
     _validateKeyBatch(newKeys);
     for (uint256 i = 0; i < newKeys.length; ++i) {
       bytes32 issHash = newKeys[i].issHash;
+      _ensureUniqueKid(newKeys[i].kid, issHash);
       uint256 keyIndex = keyIndexes[issHash];
       OIDCKeys[issHash][keyIndex] = newKeys[i];
       uint256 nextIndex = (keyIndex + 1) % MAX_KEYS; // Circular buffer
       keyIndexes[issHash] = nextIndex;
       emit KeyAdded(issHash, newKeys[i].kid, newKeys[i].n);
+    }
+  }
+
+  function _ensureUniqueKid(bytes32 kid, bytes32 issHash) internal {
+    for (uint256 i = 0; i < MAX_KEYS; i++) {
+      if (OIDCKeys[issHash][i].kid == kid) {
+        revert KidAlreadyRegistered(kid, issHash);
+      }
     }
   }
 

--- a/src/interfaces/IOidcKeyRegistry.sol
+++ b/src/interfaces/IOidcKeyRegistry.sol
@@ -55,6 +55,11 @@ interface IOidcKeyRegistry {
   /// @param chunkValue The value of the chunk that exceeded the limit.
   error ModulusChunkTooLarge(uint256 index, uint256 chunkIndex, uint256 chunkValue);
 
+  /// @notice Thrown when trying to register a key with a kid already known
+  /// @param kid key id that caused the conflict
+  /// @param issHash hash if the user where the conflict occurred
+  error KidAlreadyRegistered(bytes32 kid, bytes32 issHash);
+
   function hashIssuer(string memory iss) external pure returns (bytes32);
   function getKey(bytes32 issHash, bytes32 kid) external view returns (Key memory);
   function addKey(Key memory newKey) external;


### PR DESCRIPTION
# Description

https://defender.openzeppelin.com/#/audit/2b38545d-5f25-4e91-9ff8-e465300a0503/issues/L-01
