### PR TITLE
L-06 Delayed Recovery Validation May Compromise Account Security

### DIFF
--- a/src/OidcKeyRegistry.sol
+++ b/src/OidcKeyRegistry.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.24;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { IOidcKeyRegistry } from "./interfaces/IOidcKeyRegistry.sol";
 
 /// @title OidcKeyRegistry
 /// @author Matter Labs
 /// @custom:security-contact security@matterlabs.dev
 /// @dev This contract is used to store OIDC keys for the OIDC recovery validator.
-contract OidcKeyRegistry is IOidcKeyRegistry, Initializable, OwnableUpgradeable {
+contract OidcKeyRegistry is IOidcKeyRegistry, Initializable, Ownable2StepUpgradeable {
   /// @dev The maximum number of keys that can be added to the registry.
   uint256 public constant MAX_KEYS = 8;
 

--- a/src/interfaces/IOidcRecoveryValidator.sol
+++ b/src/interfaces/IOidcRecoveryValidator.sol
@@ -74,6 +74,7 @@ interface IOidcRecoveryValidator is IModuleValidator {
     string iss;
     bool readyToRecover;
     bytes32 pendingPasskeyHash;
+    uint256 recoveryStartedAt;
     uint256 recoverNonce;
     uint256 addedOn;
   }

--- a/src/validators/OidcRecoveryValidator.sol
+++ b/src/validators/OidcRecoveryValidator.sol
@@ -15,6 +15,7 @@ import { IValidatorManager } from "../interfaces/IValidatorManager.sol";
 import { IOidcRecoveryValidator } from "../interfaces/IOidcRecoveryValidator.sol";
 import { IOidcKeyRegistry } from "../interfaces/IOidcKeyRegistry.sol";
 import { IZkVerifier } from "../interfaces/IZkVerifier.sol";
+import { TimestampAsserterLocator } from "../helpers/TimestampAsserterLocator.sol";
 
 /// @title OidcRecoveryValidator
 /// @author Matter Labs
@@ -28,6 +29,8 @@ contract OidcRecoveryValidator is IOidcRecoveryValidator, Initializable {
   uint256 private constant BITS_IN_A_BYTE = 8;
   uint256 private constant BYTES_IN_A_WORD = 32;
   uint256 private constant LAST_BYTE_MASK = uint256(0xff);
+
+  uint256 private constant RECOVERY_VALIDITY_TIME = 10 * 60; // 10 minutes
 
   /// @notice The mapping of account addresses to their OIDC data.
   mapping(address account => OidcData oidcData) internal accountData;
@@ -159,6 +162,7 @@ contract OidcRecoveryValidator is IOidcRecoveryValidator, Initializable {
     }
 
     accountData[targetAccount].pendingPasskeyHash = data.pendingPasskeyHash;
+    accountData[targetAccount].recoveryStartedAt = block.timestamp;
     accountData[targetAccount].recoverNonce += 1;
     accountData[targetAccount].readyToRecover = true;
 
@@ -202,8 +206,14 @@ contract OidcRecoveryValidator is IOidcRecoveryValidator, Initializable {
       return false;
     }
 
+    TimestampAsserterLocator.locate().assertTimestampInRange(
+      oidcData.recoveryStartedAt,
+      oidcData.recoveryStartedAt + RECOVERY_VALIDITY_TIME
+    );
+
     // Reset pending passkey hash
     accountData[msg.sender].pendingPasskeyHash = bytes32(0);
+    accountData[msg.sender].recoveryStartedAt = 0;
     accountData[msg.sender].readyToRecover = false;
     return true;
   }


### PR DESCRIPTION
# Description

https://defender.openzeppelin.com/#/audit/2b38545d-5f25-4e91-9ff8-e465300a0503/issues/L-06

This is also related to:
https://defender.openzeppelin.com/#/audit/2b38545d-5f25-4e91-9ff8-e465300a0503/issues/L-05

Even when it's not the ideal flow, users can cancel the recovery by letting it expire (which is just 10 minutes).

