### PR TITLE
M-01 Incorrect Key Ordering in _compactKeys Function Leads to Potential Overwriting of New Keys

### DIFF
--- a/src/validators/OidcRecoveryValidator.sol
+++ b/src/validators/OidcRecoveryValidator.sol
@@ -235,10 +235,9 @@ contract OidcRecoveryValidator is IOidcRecoveryValidator, Initializable {
     return true;
   }
 
-  /// @notice Unimplemented because signature validation is not required.
-  /// @dev This module is only used to set new passkeys, arbitrary signature validation is out of the scope of this module.
-  function validateSignature(bytes32, bytes memory) external pure returns (bool) {
-    revert ValidateSignatureNotImplemented();
+  /// @inheritdoc IModuleValidator
+  function validateSignature(bytes32, bytes calldata) external pure returns (bool) {
+    return false;
   }
 
   /// @inheritdoc IERC165

--- a/test/OidcRecoveryValidatorTest.ts
+++ b/test/OidcRecoveryValidatorTest.ts
@@ -35,6 +35,13 @@ describe("OidcRecoveryValidator", function () {
     })).wait();
   });
 
+  describe("validateSignature", () => {
+    it("returns false", async () => {
+      const res = await oidcValidator.connect(testWallet).validateSignature(pad("0x01"), "0x02");
+      expect(res).to.equal(false);
+    });
+  });
+
   describe("addValidationKey", () => {
     it("should add new OIDC validation key", async function () {
       const oidcDigest = ethers.hexlify(randomBytes(32));


### PR DESCRIPTION
# Description

I was not able to reproduce this issue. I believe that it was fixed in one of the other PRs, the one about intuitive ordering for circular buffer. Still, I added more tests to ensure that works as expected.

https://defender.openzeppelin.com/#/audit/2b38545d-5f25-4e91-9ff8-e465300a0503/issues/M-01
