### PR TITLE
M-03 Unauthorized Control via Manipulated pendingPasskeyHash in startRecovery Process

### DIFF
--- a/src/validators/OidcRecoveryValidator.sol
+++ b/src/validators/OidcRecoveryValidator.sol
@@ -151,7 +151,9 @@ contract OidcRecoveryValidator is IOidcRecoveryValidator, Initializable {
     bytes32 issHash = keyRegistry.hashIssuer(oidcData.iss);
     OidcKeyRegistry.Key memory key = keyRegistry.getKey(issHash, data.kid);
 
-    bytes32 senderHash = keccak256(abi.encode(msg.sender, oidcData.recoverNonce, data.timeLimit));
+    bytes32 senderHash = keccak256(
+      abi.encode(msg.sender, targetAccount, data.pendingPasskeyHash, oidcData.recoverNonce, data.timeLimit)
+    );
 
     // Fill public inputs
     uint256[PUB_SIGNALS_LENGTH] memory publicInputs;


### PR DESCRIPTION
# Description

https://defender.openzeppelin.com/#/audit/2b38545d-5f25-4e91-9ff8-e465300a0503/issues/M-03

We went for a different approach here. Instead of adding a new public input in the circuit we kept re using the content of the nonce. We added the target address and the passkey hash to the data included in the jwt nonce. This links all the information together, making the proof totally linked to one specific recovery