### PR TITLE
fix: removed unused return value in addOidcAccount

### DIFF
--- a/src/interfaces/IOidcRecoveryValidator.sol
+++ b/src/interfaces/IOidcRecoveryValidator.sol
@@ -110,7 +110,7 @@ interface IOidcRecoveryValidator is IModuleValidator {
     uint256 timeLimit;
   }
 
-  function addOidcAccount(bytes32 oidcDigest, string memory iss) external returns (bool);
+  function addOidcAccount(bytes32 oidcDigest, string memory iss) external;
   function deleteOidcAccount() external;
   function startRecovery(StartRecoveryData calldata data, address targetAccount) external;
   function addressForDigest(bytes32 digest) external returns (address);

--- a/src/validators/OidcRecoveryValidator.sol
+++ b/src/validators/OidcRecoveryValidator.sol
@@ -93,8 +93,7 @@ contract OidcRecoveryValidator is IOidcRecoveryValidator, Initializable {
   /// @notice Adds an `OidcData` for the caller.
   /// @param oidcDigest PoseidonHash(sub || aud || iss || salt).
   /// @param iss The OIDC issuer.
-  /// @return true if the key was added, false if it was updated.
-  function addOidcAccount(bytes32 oidcDigest, string memory iss) public returns (bool) {
+  function addOidcAccount(bytes32 oidcDigest, string memory iss) public {
     if (oidcDigest == bytes32(0)) revert EmptyOidcDigest();
     if (bytes(iss).length == 0) revert EmptyOidcIssuer();
     if (bytes(iss).length > MAX_ISS_LENGTH) revert OidcIssuerTooLong();
@@ -119,7 +118,6 @@ contract OidcRecoveryValidator is IOidcRecoveryValidator, Initializable {
     digestIndex[oidcDigest] = msg.sender;
 
     emit OidcAccountUpdated(msg.sender, oidcDigest, iss, isNew);
-    return isNew;
   }
 
   /// @notice Deletes the OIDC account for the caller, freeing it for use by another SSO account.


### PR DESCRIPTION
# Description

https://defender.openzeppelin.com/#/audit/2b38545d-5f25-4e91-9ff8-e465300a0503/issues/N-18

The solution for this was just remove the return value, because it was not being used anywhere in the code base. Including the front end.