### PR TITLE
feat: perform deploy as part of upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,28 @@ smart account by signing to verify the legitimacy of the recovery process.
 6. **Cancelling recovery**\
    A pending recovery can be discarded using `discardRecovery`, which:
    1. Removes the recovery request from storage.
+
+## Deployment
+
+Chain operators can use the `deploy` script to _initially_ deploy the contracts,
+ensuring that the proxy addresses are added to the storage slot exception allow
+list. (api_web3_json_rpc: whitelisted_tokens_for_aa)
+
+```bash
+pnpm run deploy --file chainname.json
+```
+
+This list of contracts can be included into the parent SSO-SDK project for
+automatic chain support. Then subsquent updates can be made using the `upgrade`
+script, which will use the deployed proxies:
+
+```bash
+pnpm run upgrade --proxyfile chainname.json
+```
+
+Non-chain operators should use the deploy script with the no proxy flag to avoid
+the storage slot validation errors.
+
+```bash
+pnpm run deploy --file chainname.json --direct
+```

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -139,7 +139,7 @@ export async function deployCmd(
 
 task("deploy", "Deploys ZKsync SSO contracts")
   .addOptionalParam("only", "name of a specific contract to deploy")
-  .addFlag("noProxy", "do not deploy transparent proxies for factory and modules")
+  .addFlag("direct", "do not deploy transparent proxies for factory and modules")
   .addOptionalParam("implementation", "address of the account implementation to use in the beacon")
   .addOptionalParam("factory", "address of the factory to use in the paymaster")
   .addOptionalParam("sessions", "address of the sessions module to use in the paymaster")
@@ -155,7 +155,7 @@ task("deploy", "Deploys ZKsync SSO contracts")
       args,
       deployer,
       cmd.only,
-      cmd.noProxy,
+      cmd.direct,
       cmd.fund,
       cmd.file);
   });

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -3,15 +3,16 @@ import "@nomicfoundation/hardhat-toolbox";
 import { ethers } from "ethers";
 import { writeFileSync } from "fs";
 import { task } from "hardhat/config";
+import { Artifact } from "hardhat/types";
 import { Wallet } from "zksync-ethers";
 
 const WEBAUTH_NAME = "WebAuthValidator";
 const SESSIONS_NAME = "SessionKeyValidator";
-const GUARDIAN_RECOVERY_NAME = "GuardianRecoveryValidator";
 const ACCOUNT_IMPL_NAME = "SsoAccount";
 const FACTORY_NAME = "AAFactory";
 const PAYMASTER_NAME = "ExampleAuthServerPaymaster";
 const BEACON_NAME = "SsoBeacon";
+export const GUARDIAN_RECOVERY_NAME = "GuardianRecoveryValidator";
 
 async function deploy(name: string, deployer: Wallet, proxy: boolean, args?: any[], initArgs?: any): Promise<string> {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -49,7 +50,7 @@ async function fundPaymaster(deployer: Wallet, paymaster: string, fund?: string 
   }
 }
 
-function getDeployer(hre, cmd) {
+export function getDeployer(hre, cmd) {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { LOCAL_RICH_WALLETS, getProvider } = require("../test/utils");
   console.log("Deploying to:", hre.network.name);
@@ -65,7 +66,18 @@ function getDeployer(hre, cmd) {
   }
 }
 
-function getArgs(cmd) {
+interface DeployArgs {
+  only?: string;
+  noProxy?: boolean;
+  implementation?: string;
+  factory?: string;
+  sessions?: string;
+}
+
+export function getArgs(cmd: DeployArgs) {
+  if (!cmd.only) {
+    return [];
+  }
   if (cmd.only == BEACON_NAME) {
     if (!cmd.implementation) {
       throw "Account implementation (--implementation <value>) address must be provided to deploy beacon";
@@ -88,6 +100,43 @@ function getArgs(cmd) {
   throw `Unsupported '${cmd.only}' contract name. Use: ${BEACON_NAME}, ${FACTORY_NAME}, ${PAYMASTER_NAME}`;
 }
 
+export async function deployCmd(
+  recoveryArtifact: Artifact,
+  args: string[],
+  deployer: Wallet,
+  artifactName: string,
+  noProxy: boolean,
+  fund: number,
+  file: string) {
+  if (!artifactName) {
+    const passkey = await deploy(WEBAUTH_NAME, deployer, !noProxy);
+    const session = await deploy(SESSIONS_NAME, deployer, !noProxy);
+    const implementation = await deploy(ACCOUNT_IMPL_NAME, deployer, false);
+    const beacon = await deploy(BEACON_NAME, deployer, false, [implementation]);
+    const accountFactory = await deploy(FACTORY_NAME, deployer, !noProxy, [beacon, passkey, session]);
+    const guardianInterface = new ethers.Interface(recoveryArtifact.abi);
+    const recovery = await deploy(GUARDIAN_RECOVERY_NAME, deployer, !noProxy, [], guardianInterface.encodeFunctionData(
+      "initialize(address)",
+      [passkey],
+    ));
+    const accountPaymaster = await deploy(PAYMASTER_NAME, deployer, false, [accountFactory, session, recovery, passkey]);
+    await fundPaymaster(deployer, accountPaymaster, fund);
+    const deployedContracts = { beacon, session, passkey, accountFactory, accountPaymaster, recovery };
+    if (file) {
+      writeFileSync(file, JSON.stringify(deployedContracts));
+    }
+    return deployedContracts;
+  } else {
+    const deployedContract = await deploy(artifactName, deployer, false, args);
+
+    if (artifactName == PAYMASTER_NAME) {
+      await fundPaymaster(deployer, deployedContract, fund);
+    }
+
+    return { artifactName: deployedContract };
+  }
+}
+
 task("deploy", "Deploys ZKsync SSO contracts")
   .addOptionalParam("only", "name of a specific contract to deploy")
   .addFlag("noProxy", "do not deploy transparent proxies for factory and modules")
@@ -98,30 +147,15 @@ task("deploy", "Deploys ZKsync SSO contracts")
   .addOptionalParam("fund", "amount of ETH to send to the paymaster", "0")
   .addOptionalParam("file", "where to save all contract locations (it not using only)")
   .setAction(async (cmd, hre) => {
+    const recoveryArtifact = await hre.artifacts.readArtifact(GUARDIAN_RECOVERY_NAME);
+    const args = getArgs(cmd);
     const deployer = getDeployer(hre, cmd);
-    if (!cmd.only) {
-      const passkey = await deploy(WEBAUTH_NAME, deployer, !cmd.noProxy);
-      const session = await deploy(SESSIONS_NAME, deployer, !cmd.noProxy);
-      const implementation = await deploy(ACCOUNT_IMPL_NAME, deployer, false);
-      const beacon = await deploy(BEACON_NAME, deployer, false, [implementation]);
-      const accountFactory = await deploy(FACTORY_NAME, deployer, !cmd.noProxy, [beacon, passkey, session]);
-      const guardianInterface = new ethers.Interface((await hre.artifacts.readArtifact(GUARDIAN_RECOVERY_NAME)).abi);
-      const recovery = await deploy(GUARDIAN_RECOVERY_NAME, deployer, !cmd.noProxy, [], guardianInterface.encodeFunctionData(
-        "initialize(address)",
-        [passkey],
-      ));
-      const accountPaymaster = await deploy(PAYMASTER_NAME, deployer, false, [accountFactory, session, recovery, passkey]);
-      await fundPaymaster(deployer, accountPaymaster, cmd.fund);
-      if (cmd.file) {
-        writeFileSync(cmd.file, JSON.stringify({ session, passkey, accountFactory, accountPaymaster, recovery }));
-      }
-    } else {
-      const args = getArgs(cmd);
-
-      const deployedContract = await deploy(cmd.only, deployer, false, args);
-
-      if (cmd.only == PAYMASTER_NAME) {
-        await fundPaymaster(deployer, deployedContract, cmd.fund);
-      }
-    }
+    await deployCmd(
+      recoveryArtifact,
+      args,
+      deployer,
+      cmd.only,
+      cmd.noProxy,
+      cmd.fund,
+      cmd.file);
   });

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -7,7 +7,7 @@ import { deployCmd, getArgs, getDeployer, GUARDIAN_RECOVERY_NAME } from "./deplo
 
 task("upgrade", "Upgrades ZKsync SSO contracts")
   .addParam("proxyfile", "location of the file with proxy contract addresses")
-  .addOptionalParam("artifactName", "name of the artifact to upgrade to, if not upgrade all")
+  .addOptionalParam("artifactname", "name of the artifact to upgrade to, if not upgrade all")
   .setAction(async (cmd, hre) => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { LOCAL_RICH_WALLETS, getProvider } = require("../test/utils");
@@ -28,7 +28,7 @@ task("upgrade", "Upgrades ZKsync SSO contracts")
       await hre.artifacts.readArtifact(GUARDIAN_RECOVERY_NAME),
       getArgs(cmd),
       getDeployer(hre, cmd),
-      cmd.artifactName,
+      cmd.artifactname,
       true,
       0,
       "");

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -1,15 +1,16 @@
+import { ethers } from "ethers";
+import fs from "fs";
 import { task } from "hardhat/config";
 import { Wallet } from "zksync-ethers";
-import { ethers } from "ethers";
 
-// TODO: add support for constructor args
+import { deployCmd, getArgs, getDeployer, GUARDIAN_RECOVERY_NAME } from "./deploy";
+
 task("upgrade", "Upgrades ZKsync SSO contracts")
-  .addParam("proxy", "address of the proxy to upgrade")
-  .addParam("beaconAddress", "address of the beacon proxy for the upgrade")
-  .addPositionalParam("artifactName", "name of the artifact to upgrade to")
+  .addParam("proxyfile", "location of the file with proxy contract addresses")
+  .addOptionalParam("artifactName", "name of the artifact to upgrade to, if not upgrade all")
   .setAction(async (cmd, hre) => {
-    const { LOCAL_RICH_WALLETS, getProvider, deployFactory, create2, ethersStaticSalt } = require("../test/utils");
-
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { LOCAL_RICH_WALLETS, getProvider } = require("../test/utils");
     let privateKey: string;
     if (hre.network.name == "inMemoryNode" || hre.network.name == "dockerizedNode") {
       console.log("Using local rich wallet");
@@ -21,21 +22,31 @@ task("upgrade", "Upgrades ZKsync SSO contracts")
     }
 
     const wallet = new Wallet(privateKey, getProvider());
-    let newImpl;
 
     console.log("Deploying new implementation of", cmd.artifactName, "contract...");
-    if (cmd.artifactName == "AAFactory") {
-      if (!cmd.beaconAddress) throw "Deploying the AAFactory requires a Beacon Address '--beacon-address <value>'";
-      newImpl = await deployFactory(wallet, cmd.beaconAddress);
-    } else {
-      newImpl = await create2(cmd.artifactName, wallet, ethersStaticSalt, []);
-    }
-    console.log("New implementation deployed at:", await newImpl.getAddress());
+    const deployedContracts = await deployCmd(
+      await hre.artifacts.readArtifact(GUARDIAN_RECOVERY_NAME),
+      getArgs(cmd),
+      getDeployer(hre, cmd),
+      cmd.artifactName,
+      true,
+      0,
+      "");
 
-    console.log("Upgrading proxy at", cmd.proxy, "to new implementation...");
-    const abi = ["function upgradeTo(address newImplementation)"];
-    const proxy = new ethers.Contract(cmd.proxy, abi, wallet);
-    const tx = await proxy.upgradeTo(await newImpl.getAddress());
-    await tx.wait();
-    console.log("Proxy upgraded successfully");
-});
+    for (const [contractName, contractAddress] of Object.entries(deployedContracts)) {
+      console.log(`New ${contractName} implementation deployed at ${contractAddress}`);
+      if ("accountPaymaster" == contractName) {
+        console.log("ExampleAuthServerPaymaster not a proxy");
+        continue;
+      }
+
+      const proxyAddresses = JSON.parse(fs.readFileSync(cmd.proxyfile).toString());
+      const proxyAddress = proxyAddresses[contractName];
+      console.log("Upgrading proxy at", proxyAddress);
+      const abi = ["function upgradeTo(address newImplementation)"];
+      const proxy = new ethers.Contract(proxyAddress, abi, wallet);
+      const tx = await proxy.upgradeTo(contractAddress);
+      await tx.wait();
+      console.log("Proxy upgraded successfully");
+    }
+  });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -29,14 +29,13 @@ import {
   AAFactory__factory,
   AccountProxy__factory,
   ERC20__factory,
-  ExampleAuthServerPaymaster__factory,
+  ERC1271Caller__factory, ExampleAuthServerPaymaster__factory,
   GuardianRecoveryValidator__factory,
   SessionKeyValidator__factory,
   SsoAccount__factory,
   SsoBeacon__factory,
   TestPaymaster__factory,
-  WebAuthValidator__factory,
-  ERC1271Caller__factory } from "../typechain-types";
+  WebAuthValidator__factory } from "../typechain-types";
 
 export const ethersStaticSalt = new Uint8Array([
   205, 241, 161, 186, 101, 105, 79,


### PR DESCRIPTION
# Description

Update upgrade script to perform full deploy and use the file format from the deploy to maintain the proxy addresses.

## Additional context

Because we have to add proxy addresses to an allow list, updating the proxy breaks old accounts. Ideally we never do a fresh deploy again!