### PR TITLE
[feat] Tests for AllowedSessionsValidator

### DIFF
--- a/src/validators/AllowedSessionsValidator.sol
+++ b/src/validators/AllowedSessionsValidator.sol
@@ -87,7 +87,7 @@ contract AllowedSessionsValidator is SessionKeyValidator, AccessControl, IAllowe
     if (!areSessionActionsAllowed[sessionActionsHash]) {
       revert Errors.SESSION_ACTIONS_NOT_ALLOWED(sessionActionsHash);
     }
-    super.createSession(sessionSpec);
+    SessionKeyValidator.createSession(sessionSpec);
   }
 
   /// @inheritdoc SessionKeyValidator

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -322,7 +322,7 @@ describe('AllowedSessionsValidator tests', () => {
           target: "0x000000000000000000000000000000000000000a",
           selector: "0xcafebabe",
           maxValuePerUse: hre.ethers.parseEther("0.05"),
-          valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.25"), period: 3600n },
+          valueLimit: { limitType: 2n, limit: hre.ethers.parseEther("0.25"), period: 3600n },
           constraints: [],
         },
       ]

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -312,7 +312,7 @@ describe('AllowedSessionsValidator tests', () => {
       signer: await tester.sessionOwner.getAddress(),
       expiresAt: mockedTime,
       feeLimit: {
-        limitType: 1n,
+        limitType: 2n,
         limit: hre.ethers.parseEther("1"),
         period: 3600n,
       },
@@ -325,7 +325,7 @@ describe('AllowedSessionsValidator tests', () => {
           valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.25"), period: 3600n },
           constraints: [],
         },
-      ],
+      ]
     };
 
     const sessionActionsHash = getSessionActionsHash(sessionSpec);

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -349,7 +349,7 @@ describe('AllowedSessionsValidator tests', () => {
       ]
     }
 
-    await tester.createSession(sessionSpecAsPartial);
+    await tester.createSession(sessionSpecAsPartial, true); // using the allowed sessions contract
 
     // Now remove the session actions from allowed list
     await validator.setSessionActionsAllowed(sessionActionsHash, false);
@@ -357,7 +357,7 @@ describe('AllowedSessionsValidator tests', () => {
 
     // Creating the same session should now fail
     await expect(
-      await tester.createSession(sessionSpecAsPartial)
+      await tester.createSession(sessionSpecAsPartial, true) // using the allowed sessions contract
     ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
   });
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -309,7 +309,7 @@ describe('AllowedSessionsValidator tests', () => {
     const tester = new SessionTester(standardCreate2Address, await fixtures.getAllowedSessionsContractAddress());
 
     const sessionSpec: SessionSpec = {
-      signer: await fixtures.wallet.getAddress(),
+      signer: await tester.sessionOwner.getAddress(),
       expiresAt: mockedTime,
       feeLimit: {
         limitType: 1n,
@@ -343,7 +343,10 @@ describe('AllowedSessionsValidator tests', () => {
           target: sessionSpec.callPolicies[0].target,
           selector: sessionSpec.callPolicies[0].selector,
           maxValuePerUse: sessionSpec.callPolicies[0].maxValuePerUse,
-          valueLimit: sessionSpec.callPolicies[0].valueLimit,
+          valueLimit: {
+            limit: sessionSpec.callPolicies[0].valueLimit.limit,
+            period: sessionSpec.callPolicies[0].valueLimit.period
+          },
           constraints: []
         }
       ]

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -356,39 +356,6 @@ describe('AllowedSessionsValidator tests', () => {
     ).to.be.revertedWithCustomError(validator, "SESSION_CALL_POLICY_BANNED");
   });
 
-  it('should not allow SessionSpec actions if they are banned', async () => {
-    const validator = await fixtures.getAllowedSessionsContract();
-    const sessionSpec: SessionSpec = {
-      signer: await fixtures.wallet.getAddress(),
-      expiresAt: mockedTime,
-      feeLimit: {
-        limitType: 1n,
-        limit: hre.ethers.parseEther("1"),
-        period: 3600n,
-      },
-      transferPolicies: [],
-      callPolicies: [
-        {
-          target: await validator.getAddress(),
-          selector: "0xdeadbeef",
-          maxValuePerUse: hre.ethers.parseEther("0.01"),
-          valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.1"), period: 3600n },
-          constraints: [],
-        },
-      ],
-    };
-
-    const sessionActionsHash = getSessionActionsHash(sessionSpec);
-
-    await expect(
-      validator.setSessionActionsAllowed(sessionActionsHash, true) // ensure it's not allowed
-    ).not.to.be.reverted;
-
-    await expect(
-      validator.createSession(sessionSpec)
-    ).to.be.revertedWithCustomError(validator, "SESSION_CALL_POLICY_BANNED");
-  });
-
   it('should reject a former valid session after being removed from allowed list', async () => {
     const validator = await fixtures.getAllowedSessionsContract();
     const validatorAddress = await fixtures.getAllowedSessionsContractAddress();

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -317,6 +317,10 @@ describe('AllowedSessionsValidator tests', () => {
       }],
     });
     const initSessionData = abiCoder.encode(validator.interface.getFunction("createSession").inputs, [initialSession]);
+    const initialSessionActionsHash = await validator.getSessionActionsHash(initialSession);
+
+    // First, allow the initial session actions
+    await validator.setSessionActionsAllowed(initialSessionActionsHash, true);
 
     const sessionKeyPayload = abiCoder.encode(["address", "bytes"], [validatorAddress, initSessionData]);
     const deployTx = await factoryContract.deployProxySsoAccount(

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -335,6 +335,7 @@ describe('AllowedSessionsValidator tests', () => {
     expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
 
     const sessionSpecAsPartial: PartialSession = {
+      expiresAt: parseInt(sessionSpec.expiresAt.toString()),
       feeLimit: getLimit({ limit: sessionSpec.feeLimit.limit, period: sessionSpec.feeLimit.period }),
       callPolicies: [
         {
@@ -351,6 +352,7 @@ describe('AllowedSessionsValidator tests', () => {
     }
 
     console.log(sessionSpec);
+    console.log(sessionSpec.callPolicies![0].valueLimit);
     console.log('----------------------');
     console.log(sessionSpecAsPartial);
     console.log(sessionSpecAsPartial.callPolicies![0].valueLimit);

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -4,7 +4,7 @@ import { solidityPacked, keccak256, Wallet, randomBytes } from "ethers";
 import hre from "hardhat";
 import { utils } from "zksync-ethers";
 import { ContractFixtures } from "./utils";
-import { PartialSession, SessionTester } from "./SessionKeyTest";
+import { PartialSession, SessionTester, getLimit } from "./SessionKeyTest";
 
 type SessionSpec = {
   signer: string;
@@ -309,7 +309,7 @@ describe('AllowedSessionsValidator tests', () => {
     const tester = new SessionTester(standardCreate2Address, await fixtures.getAllowedSessionsContractAddress());
 
     const sessionSpec: SessionSpec = {
-      signer: await tester.sessionOwner.getAddress(),
+      signer: tester.sessionOwner.address,
       expiresAt: mockedTime,
       feeLimit: {
         limitType: 2n,
@@ -335,9 +335,7 @@ describe('AllowedSessionsValidator tests', () => {
     expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
 
     const sessionSpecAsPartial: PartialSession = {
-      expiresAt: parseInt(sessionSpec.expiresAt.toString()),
-      feeLimit: sessionSpec.feeLimit,
-      transferPolicies: sessionSpec.transferPolicies,
+      feeLimit: getLimit({ limit: sessionSpec.feeLimit.limit, period: sessionSpec.feeLimit.period }),
       callPolicies: [
         {
           target: sessionSpec.callPolicies[0].target,

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -353,6 +353,9 @@ describe('AllowedSessionsValidator tests', () => {
     console.log(sessionSpec);
     console.log('----------------------');
     console.log(sessionSpecAsPartial);
+    console.log(sessionSpecAsPartial.callPolicies![0].valueLimit);
+    console.log('***********************');
+    
 
     await tester.createSession(sessionSpecAsPartial, true); // using the allowed sessions contract
 

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -47,7 +47,7 @@ type SessionSpec = {
 const fixtures = new ContractFixtures();
 
 describe("AllowedSessionsValidator tests", function () {
-  describe('AllowedSessionsValidator (for zkxsolla and zkxsollaStaging network testing)', () => {
+  describe('AllowedSessionsValidator (actual)', () => {
     let mockedTime: bigint = BigInt(Math.floor(Date.now() / 1000) + 3600); // 1 hour from now;;
 
     const getSessionActionsHash = (sessionSpec: SessionSpec) => {
@@ -262,6 +262,6 @@ describe("AllowedSessionsValidator tests", function () {
       expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
     });
   });
-  
-  performSessionKeyTestDescribe(fixtures.getAllowedSessionsContractAddress, fixtures.getAllowedSessionsContract);
+
+  performSessionKeyTestDescribe(fixtures.getAllowedSessionsContractAddress, fixtures.getAllowedSessionsContract, "Tests of the parent (SessionKeyModule)");
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -3,7 +3,6 @@ import { it } from "mocha";
 import { solidityPacked, keccak256 } from "ethers";
 import hre from "hardhat";
 import { ContractFixtures } from "./utils";
-import { performSessionKeyTestDescribe } from "./SessionKeyTest";
 
 type SessionSpec = {
   signer: string;
@@ -262,6 +261,4 @@ describe("AllowedSessionsValidator tests", function () {
       expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
     });
   });
-
-  // performSessionKeyTestDescribe(fixtures.getAllowedSessionsContractAddress, fixtures.getAllowedSessionsContract, "Tests of the parent (SessionKeyModule)");
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -391,9 +391,9 @@ describe('AllowedSessionsValidator tests', () => {
     await validator.setSessionActionsAllowed(sessionActionsHash, false);
     expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.false;
 
-    // // Creating the same session should now fail
-    // await expect(
-    //   await tester.createSession(sessionSpecAsPartial, true) // using the allowed sessions contract
-    // ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
+    // Creating the same session should now fail
+    await expect(
+      tester.createSession(sessionSpecAsPartial, true)
+    ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
   });
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -356,9 +356,9 @@ describe('AllowedSessionsValidator tests', () => {
     await validator.setSessionActionsAllowed(sessionActionsHash, false);
     expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.false;
 
-    // // Creating the same session should now fail
-    // await expect(
-    //   await tester.createSession(sessionSpecAsPartial, true) // using the allowed sessions contract
-    // ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
+    // Creating the same session should now fail
+    await expect(
+      await tester.createSession(sessionSpecAsPartial, true) // using the allowed sessions contract
+    ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
   });
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -1,0 +1,267 @@
+import { assert, expect } from "chai";
+import { it } from "mocha";
+import { solidityPacked, keccak256 } from "ethers";
+import hre from "hardhat";
+import { ContractFixtures } from "./utils";
+import { performSessionKeyTestDescribe } from "./SessionKeyTest";
+
+type SessionSpec = {
+  signer: string;
+  expiresAt: bigint;
+  feeLimit: {
+    limitType: bigint;
+    limit: bigint;
+    period: bigint;
+  };
+  transferPolicies: Array<{
+    target: string;
+    maxValuePerUse: bigint;
+    valueLimit: {
+      limitType: bigint;
+      limit: bigint;
+      period: bigint;
+    };
+  }>;
+  callPolicies: Array<{
+    target: string;
+    selector: string;
+    maxValuePerUse: bigint;
+    valueLimit: {
+      limitType: bigint;
+      limit: bigint;
+      period: bigint;
+    };
+    constraints: Array<{
+      condition: bigint;
+      index: number;
+      refValue: string;
+      limit: {
+        limitType: bigint;
+        limit: bigint;
+        period: bigint;
+      };
+    }>;
+  }>;
+};
+
+const fixtures = new ContractFixtures();
+
+describe("AllowedSessionsValidator tests", function () {
+  describe('AllowedSessionsValidator (for zkxsolla and zkxsollaStaging network testing)', () => {
+    let mockedTime: bigint = BigInt(Math.floor(Date.now() / 1000) + 3600); // 1 hour from now;;
+
+    const getSessionActionsHash = (sessionSpec: SessionSpec) => {
+      let callPoliciesEncoded: any;
+      for (const callPolicy of sessionSpec.callPolicies) {
+        callPoliciesEncoded = solidityPacked(
+          callPoliciesEncoded !== undefined
+            ? ["bytes", "bytes20", "bytes4", "uint256", "uint256", "uint256", "uint256"]
+            : ["bytes20", "bytes4", "uint256", "uint256", "uint256", "uint256"],
+          callPoliciesEncoded !== undefined
+            ? [
+              callPoliciesEncoded,
+              callPolicy.target,
+              callPolicy.selector,
+              callPolicy.maxValuePerUse,
+              callPolicy.valueLimit.limitType,
+              callPolicy.valueLimit.limit,
+              callPolicy.valueLimit.period
+            ]
+            : [
+              callPolicy.target,
+              callPolicy.selector,
+              callPolicy.maxValuePerUse,
+              callPolicy.valueLimit.limitType,
+              callPolicy.valueLimit.limit,
+              callPolicy.valueLimit.period
+            ]
+        );
+      }
+      return keccak256(hre.ethers.AbiCoder.defaultAbiCoder().encode(
+        [
+          "tuple(uint256 limitType, uint256 limit, uint256 period)",
+          "tuple(address target, uint256 maxValuePerUse, tuple(uint256 limitType, uint256 limit, uint256 period) valueLimit)[]",
+          "bytes"
+        ],
+        [
+          sessionSpec.feeLimit,
+          sessionSpec.transferPolicies,
+          callPoliciesEncoded
+        ]
+      ));
+    };
+
+    it('should deploy AllowedSessionsValidator', async () => {
+      const allowedSessionsValidator = await fixtures.getAllowedSessionsContract();
+      assert(allowedSessionsValidator != null, "No AllowedSessionsValidator deployed");
+    });
+
+    it('should offchain and onchain SessionSpec actions hashes match', async () => {
+      const validator = await fixtures.getAllowedSessionsContract();
+      const sessionSpec: SessionSpec = {
+        signer: await fixtures.wallet.getAddress(), // Example signer
+        expiresAt: mockedTime,
+        feeLimit: {
+          limitType: 1n,
+          limit: hre.ethers.parseEther("1"),
+          period: 3600n,
+        },
+        transferPolicies: [],
+        callPolicies: [
+          {
+            target: "0x0000000000000000000000000000000000000001",
+            selector: "0x12345678",
+            maxValuePerUse: hre.ethers.parseEther("0.1"),
+            valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.5"), period: 3600n },
+            constraints: [],
+          },
+        ],
+      };
+
+      const sessionActionsHashOnchain = await validator.getSessionActionsHash(sessionSpec);
+      const sessionActionsHashOffchain = getSessionActionsHash(sessionSpec);
+      expect(sessionActionsHashOnchain).to.equal(sessionActionsHashOffchain);
+    });
+
+    it('should construct and allow SessionSpec actions (with onchain session actions hash generation)', async () => {
+      const validator = await fixtures.getAllowedSessionsContract();
+      const sessionSpec: SessionSpec = {
+        signer: await fixtures.wallet.getAddress(),
+        expiresAt: mockedTime,
+        feeLimit: {
+          limitType: 1n,
+          limit: hre.ethers.parseEther("1"),
+          period: 3600n,
+        },
+        transferPolicies: [],
+        callPolicies: [
+          {
+            target: "0x0000000000000000000000000000000000000001",
+            selector: "0x12345678",
+            maxValuePerUse: hre.ethers.parseEther("0.1"),
+            valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.5"), period: 3600n },
+            constraints: [],
+          },
+        ],
+      };
+
+      const sessionActionsHash = await validator.getSessionActionsHash(sessionSpec);
+      await validator.setSessionActionsAllowed(sessionActionsHash, true);
+
+      expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
+    });
+
+    it('should construct and allow SessionSpec actions (with offchain session actions hash generation)', async () => {
+      const validator = await fixtures.getAllowedSessionsContract();
+      const sessionSpec: SessionSpec = {
+        signer: await fixtures.wallet.getAddress(),
+        expiresAt: mockedTime,
+        feeLimit: {
+          limitType: 2n,
+          limit: hre.ethers.parseEther("2"),
+          period: 7200n,
+        },
+        transferPolicies: [],
+        callPolicies: [
+          {
+            target: "0x0000000000000000000000000000000000000002",
+            selector: "0x87654321",
+            maxValuePerUse: hre.ethers.parseEther("0.2"),
+            valueLimit: { limitType: 2n, limit: hre.ethers.parseEther("1"), period: 7200n },
+            constraints: [],
+          },
+        ],
+      };
+
+      const sessionActionsHash = getSessionActionsHash(sessionSpec);
+      await validator.setSessionActionsAllowed(sessionActionsHash, true);
+
+      expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
+    });
+
+    it('should allow SessionSpec with multiple transfer and call policies', async () => {
+      const validator = await fixtures.getAllowedSessionsContract();
+      const sessionSpec: SessionSpec = {
+        signer: await fixtures.wallet.getAddress(),
+        expiresAt: mockedTime,
+        feeLimit: {
+          limitType: 1n,
+          limit: hre.ethers.parseEther("3"),
+          period: 10800n,
+        },
+        transferPolicies: [
+          {
+            target: "0x0000000000000000000000000000000000000003",
+            maxValuePerUse: hre.ethers.parseEther("0.3"),
+            valueLimit: {
+              limitType: 1n,
+              limit: hre.ethers.parseEther("1"),
+              period: 10800n,
+            },
+          },
+          {
+            target: "0x0000000000000000000000000000000000000004",
+            maxValuePerUse: hre.ethers.parseEther("0.4"),
+            valueLimit: {
+              limitType: 2n,
+              limit: hre.ethers.parseEther("2"),
+              period: 21600n,
+            },
+          },
+        ],
+        callPolicies: [
+          {
+            target: "0x0000000000000000000000000000000000000005",
+            selector: "0xabcdef12",
+            maxValuePerUse: hre.ethers.parseEther("0.05"),
+            valueLimit: {
+              limitType: 1n,
+              limit: hre.ethers.parseEther("0.2"),
+              period: 10800n,
+            },
+            constraints: [
+              {
+                condition: 0n,
+                index: 0,
+                refValue: "0x0000000000000000000000000000000000000006",
+                limit: {
+                  limitType: 1n,
+                  limit: hre.ethers.parseEther("0.1"),
+                  period: 10800n,
+                },
+              },
+            ],
+          },
+          {
+            target: "0x0000000000000000000000000000000000000007",
+            selector: "0x1234abcd",
+            maxValuePerUse: hre.ethers.parseEther("0.07"),
+            valueLimit: {
+              limitType: 2n,
+              limit: hre.ethers.parseEther("0.3"),
+              period: 21600n,
+            },
+            constraints: [
+              {
+                condition: 1n,
+                index: 1,
+                refValue: "0x0000000000000000000000000000000000000008",
+                limit: {
+                  limitType: 2n,
+                  limit: hre.ethers.parseEther("0.2"),
+                  period: 21600n,
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const sessionActionsHash = getSessionActionsHash(sessionSpec);
+      await validator.setSessionActionsAllowed(sessionActionsHash, true);
+      expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
+    });
+  });
+  
+  performSessionKeyTestDescribe(fixtures.getAllowedSessionsContractAddress, fixtures.getAllowedSessionsContract);
+});

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -391,9 +391,9 @@ describe('AllowedSessionsValidator tests', () => {
     await validator.setSessionActionsAllowed(sessionActionsHash, false);
     expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.false;
 
-    // Creating the same session should now fail
-    await expect(
-      await tester.createSession(sessionSpecAsPartial, true) // using the allowed sessions contract
-    ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
+    // // Creating the same session should now fail
+    // await expect(
+    //   await tester.createSession(sessionSpecAsPartial, true) // using the allowed sessions contract
+    // ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
   });
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -298,7 +298,7 @@ describe('AllowedSessionsValidator tests', () => {
 
   it('should reject a former valid session after being removed from allowed list', async () => {
     const validator = await fixtures.getAllowedSessionsContract();
-    const factoryContract = await fixtures.getAaFactory();
+    const factoryContract = await fixtures.getAaFactory(true); // using allowed sessions contract
 
     // create a session to encode (before the account is deployed)
     const args = await factoryContract.getEncodedBeacon();
@@ -350,14 +350,6 @@ describe('AllowedSessionsValidator tests', () => {
         }
       ]
     }
-
-    console.log(sessionSpec);
-    console.log(sessionSpec.callPolicies![0].valueLimit);
-    console.log('----------------------');
-    console.log(sessionSpecAsPartial);
-    console.log(sessionSpecAsPartial.callPolicies![0].valueLimit);
-    console.log('***********************');
-    
 
     await tester.createSession(sessionSpecAsPartial, true); // using the allowed sessions contract
 

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -323,7 +323,7 @@ describe('AllowedSessionsValidator tests', () => {
     expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
     
     // Create session should work
-    await expect(validator.createSession(sessionSpec)).not.to.be.reverted;
+    await validator.createSession(sessionSpec);
     
     // Now remove the session actions from allowed list
     await validator.setSessionActionsAllowed(sessionActionsHash, false);

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -364,7 +364,7 @@ describe('AllowedSessionsValidator tests', () => {
 
     const sessionActionsHash = getSessionActionsHash(sessionSpec);
 
-    // First, allow the session actions
+    // Than, allow the session actions
     await validator.setSessionActionsAllowed(sessionActionsHash, true);
     expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
 

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -45,220 +45,218 @@ type SessionSpec = {
 
 const fixtures = new ContractFixtures();
 
-describe("AllowedSessionsValidator tests", function () {
-  describe('AllowedSessionsValidator (actual)', () => {
-    let mockedTime: bigint = BigInt(Math.floor(Date.now() / 1000) + 3600); // 1 hour from now;;
+describe('AllowedSessionsValidator tests', () => {
+  let mockedTime: bigint = BigInt(Math.floor(Date.now() / 1000) + 3600); // 1 hour from now;;
 
-    const getSessionActionsHash = (sessionSpec: SessionSpec) => {
-      let callPoliciesEncoded: any;
-      for (const callPolicy of sessionSpec.callPolicies) {
-        callPoliciesEncoded = solidityPacked(
-          callPoliciesEncoded !== undefined
-            ? ["bytes", "bytes20", "bytes4", "uint256", "uint256", "uint256", "uint256"]
-            : ["bytes20", "bytes4", "uint256", "uint256", "uint256", "uint256"],
-          callPoliciesEncoded !== undefined
-            ? [
-              callPoliciesEncoded,
-              callPolicy.target,
-              callPolicy.selector,
-              callPolicy.maxValuePerUse,
-              callPolicy.valueLimit.limitType,
-              callPolicy.valueLimit.limit,
-              callPolicy.valueLimit.period
-            ]
-            : [
-              callPolicy.target,
-              callPolicy.selector,
-              callPolicy.maxValuePerUse,
-              callPolicy.valueLimit.limitType,
-              callPolicy.valueLimit.limit,
-              callPolicy.valueLimit.period
-            ]
-        );
-      }
-      return keccak256(hre.ethers.AbiCoder.defaultAbiCoder().encode(
-        [
-          "tuple(uint256 limitType, uint256 limit, uint256 period)",
-          "tuple(address target, uint256 maxValuePerUse, tuple(uint256 limitType, uint256 limit, uint256 period) valueLimit)[]",
-          "bytes"
-        ],
-        [
-          sessionSpec.feeLimit,
-          sessionSpec.transferPolicies,
-          callPoliciesEncoded
-        ]
-      ));
+  const getSessionActionsHash = (sessionSpec: SessionSpec) => {
+    let callPoliciesEncoded: any;
+    for (const callPolicy of sessionSpec.callPolicies) {
+      callPoliciesEncoded = solidityPacked(
+        callPoliciesEncoded !== undefined
+          ? ["bytes", "bytes20", "bytes4", "uint256", "uint256", "uint256", "uint256"]
+          : ["bytes20", "bytes4", "uint256", "uint256", "uint256", "uint256"],
+        callPoliciesEncoded !== undefined
+          ? [
+            callPoliciesEncoded,
+            callPolicy.target,
+            callPolicy.selector,
+            callPolicy.maxValuePerUse,
+            callPolicy.valueLimit.limitType,
+            callPolicy.valueLimit.limit,
+            callPolicy.valueLimit.period
+          ]
+          : [
+            callPolicy.target,
+            callPolicy.selector,
+            callPolicy.maxValuePerUse,
+            callPolicy.valueLimit.limitType,
+            callPolicy.valueLimit.limit,
+            callPolicy.valueLimit.period
+          ]
+      );
+    }
+    return keccak256(hre.ethers.AbiCoder.defaultAbiCoder().encode(
+      [
+        "tuple(uint256 limitType, uint256 limit, uint256 period)",
+        "tuple(address target, uint256 maxValuePerUse, tuple(uint256 limitType, uint256 limit, uint256 period) valueLimit)[]",
+        "bytes"
+      ],
+      [
+        sessionSpec.feeLimit,
+        sessionSpec.transferPolicies,
+        callPoliciesEncoded
+      ]
+    ));
+  };
+
+  it('should deploy AllowedSessionsValidator', async () => {
+    const allowedSessionsValidator = await fixtures.getAllowedSessionsContract();
+    assert(allowedSessionsValidator != null, "No AllowedSessionsValidator deployed");
+  });
+
+  it('should offchain and onchain SessionSpec actions hashes match', async () => {
+    const validator = await fixtures.getAllowedSessionsContract();
+    const sessionSpec: SessionSpec = {
+      signer: await fixtures.wallet.getAddress(), // Example signer
+      expiresAt: mockedTime,
+      feeLimit: {
+        limitType: 1n,
+        limit: hre.ethers.parseEther("1"),
+        period: 3600n,
+      },
+      transferPolicies: [],
+      callPolicies: [
+        {
+          target: "0x0000000000000000000000000000000000000001",
+          selector: "0x12345678",
+          maxValuePerUse: hre.ethers.parseEther("0.1"),
+          valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.5"), period: 3600n },
+          constraints: [],
+        },
+      ],
     };
 
-    it('should deploy AllowedSessionsValidator', async () => {
-      const allowedSessionsValidator = await fixtures.getAllowedSessionsContract();
-      assert(allowedSessionsValidator != null, "No AllowedSessionsValidator deployed");
-    });
+    const sessionActionsHashOnchain = await validator.getSessionActionsHash(sessionSpec);
+    const sessionActionsHashOffchain = getSessionActionsHash(sessionSpec);
+    expect(sessionActionsHashOnchain).to.equal(sessionActionsHashOffchain);
+  });
 
-    it('should offchain and onchain SessionSpec actions hashes match', async () => {
-      const validator = await fixtures.getAllowedSessionsContract();
-      const sessionSpec: SessionSpec = {
-        signer: await fixtures.wallet.getAddress(), // Example signer
-        expiresAt: mockedTime,
-        feeLimit: {
-          limitType: 1n,
-          limit: hre.ethers.parseEther("1"),
-          period: 3600n,
+  it('should construct and allow SessionSpec actions (with onchain session actions hash generation)', async () => {
+    const validator = await fixtures.getAllowedSessionsContract();
+    const sessionSpec: SessionSpec = {
+      signer: await fixtures.wallet.getAddress(),
+      expiresAt: mockedTime,
+      feeLimit: {
+        limitType: 1n,
+        limit: hre.ethers.parseEther("1"),
+        period: 3600n,
+      },
+      transferPolicies: [],
+      callPolicies: [
+        {
+          target: "0x0000000000000000000000000000000000000001",
+          selector: "0x12345678",
+          maxValuePerUse: hre.ethers.parseEther("0.1"),
+          valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.5"), period: 3600n },
+          constraints: [],
         },
-        transferPolicies: [],
-        callPolicies: [
-          {
-            target: "0x0000000000000000000000000000000000000001",
-            selector: "0x12345678",
-            maxValuePerUse: hre.ethers.parseEther("0.1"),
-            valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.5"), period: 3600n },
-            constraints: [],
-          },
-        ],
-      };
+      ],
+    };
 
-      const sessionActionsHashOnchain = await validator.getSessionActionsHash(sessionSpec);
-      const sessionActionsHashOffchain = getSessionActionsHash(sessionSpec);
-      expect(sessionActionsHashOnchain).to.equal(sessionActionsHashOffchain);
-    });
+    const sessionActionsHash = await validator.getSessionActionsHash(sessionSpec);
+    await validator.setSessionActionsAllowed(sessionActionsHash, true);
 
-    it('should construct and allow SessionSpec actions (with onchain session actions hash generation)', async () => {
-      const validator = await fixtures.getAllowedSessionsContract();
-      const sessionSpec: SessionSpec = {
-        signer: await fixtures.wallet.getAddress(),
-        expiresAt: mockedTime,
-        feeLimit: {
-          limitType: 1n,
-          limit: hre.ethers.parseEther("1"),
-          period: 3600n,
+    expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
+  });
+
+  it('should construct and allow SessionSpec actions (with offchain session actions hash generation)', async () => {
+    const validator = await fixtures.getAllowedSessionsContract();
+    const sessionSpec: SessionSpec = {
+      signer: await fixtures.wallet.getAddress(),
+      expiresAt: mockedTime,
+      feeLimit: {
+        limitType: 2n,
+        limit: hre.ethers.parseEther("2"),
+        period: 7200n,
+      },
+      transferPolicies: [],
+      callPolicies: [
+        {
+          target: "0x0000000000000000000000000000000000000002",
+          selector: "0x87654321",
+          maxValuePerUse: hre.ethers.parseEther("0.2"),
+          valueLimit: { limitType: 2n, limit: hre.ethers.parseEther("1"), period: 7200n },
+          constraints: [],
         },
-        transferPolicies: [],
-        callPolicies: [
-          {
-            target: "0x0000000000000000000000000000000000000001",
-            selector: "0x12345678",
-            maxValuePerUse: hre.ethers.parseEther("0.1"),
-            valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.5"), period: 3600n },
-            constraints: [],
+      ],
+    };
+
+    const sessionActionsHash = getSessionActionsHash(sessionSpec);
+    await validator.setSessionActionsAllowed(sessionActionsHash, true);
+
+    expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
+  });
+
+  it('should allow SessionSpec with multiple transfer and call policies', async () => {
+    const validator = await fixtures.getAllowedSessionsContract();
+    const sessionSpec: SessionSpec = {
+      signer: await fixtures.wallet.getAddress(),
+      expiresAt: mockedTime,
+      feeLimit: {
+        limitType: 1n,
+        limit: hre.ethers.parseEther("3"),
+        period: 10800n,
+      },
+      transferPolicies: [
+        {
+          target: "0x0000000000000000000000000000000000000003",
+          maxValuePerUse: hre.ethers.parseEther("0.3"),
+          valueLimit: {
+            limitType: 1n,
+            limit: hre.ethers.parseEther("1"),
+            period: 10800n,
           },
-        ],
-      };
-
-      const sessionActionsHash = await validator.getSessionActionsHash(sessionSpec);
-      await validator.setSessionActionsAllowed(sessionActionsHash, true);
-
-      expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
-    });
-
-    it('should construct and allow SessionSpec actions (with offchain session actions hash generation)', async () => {
-      const validator = await fixtures.getAllowedSessionsContract();
-      const sessionSpec: SessionSpec = {
-        signer: await fixtures.wallet.getAddress(),
-        expiresAt: mockedTime,
-        feeLimit: {
-          limitType: 2n,
-          limit: hre.ethers.parseEther("2"),
-          period: 7200n,
         },
-        transferPolicies: [],
-        callPolicies: [
-          {
-            target: "0x0000000000000000000000000000000000000002",
-            selector: "0x87654321",
-            maxValuePerUse: hre.ethers.parseEther("0.2"),
-            valueLimit: { limitType: 2n, limit: hre.ethers.parseEther("1"), period: 7200n },
-            constraints: [],
+        {
+          target: "0x0000000000000000000000000000000000000004",
+          maxValuePerUse: hre.ethers.parseEther("0.4"),
+          valueLimit: {
+            limitType: 2n,
+            limit: hre.ethers.parseEther("2"),
+            period: 21600n,
           },
-        ],
-      };
-
-      const sessionActionsHash = getSessionActionsHash(sessionSpec);
-      await validator.setSessionActionsAllowed(sessionActionsHash, true);
-
-      expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
-    });
-
-    it('should allow SessionSpec with multiple transfer and call policies', async () => {
-      const validator = await fixtures.getAllowedSessionsContract();
-      const sessionSpec: SessionSpec = {
-        signer: await fixtures.wallet.getAddress(),
-        expiresAt: mockedTime,
-        feeLimit: {
-          limitType: 1n,
-          limit: hre.ethers.parseEther("3"),
-          period: 10800n,
         },
-        transferPolicies: [
-          {
-            target: "0x0000000000000000000000000000000000000003",
-            maxValuePerUse: hre.ethers.parseEther("0.3"),
-            valueLimit: {
-              limitType: 1n,
-              limit: hre.ethers.parseEther("1"),
-              period: 10800n,
-            },
+      ],
+      callPolicies: [
+        {
+          target: "0x0000000000000000000000000000000000000005",
+          selector: "0xabcdef12",
+          maxValuePerUse: hre.ethers.parseEther("0.05"),
+          valueLimit: {
+            limitType: 1n,
+            limit: hre.ethers.parseEther("0.2"),
+            period: 10800n,
           },
-          {
-            target: "0x0000000000000000000000000000000000000004",
-            maxValuePerUse: hre.ethers.parseEther("0.4"),
-            valueLimit: {
-              limitType: 2n,
-              limit: hre.ethers.parseEther("2"),
-              period: 21600n,
-            },
-          },
-        ],
-        callPolicies: [
-          {
-            target: "0x0000000000000000000000000000000000000005",
-            selector: "0xabcdef12",
-            maxValuePerUse: hre.ethers.parseEther("0.05"),
-            valueLimit: {
-              limitType: 1n,
-              limit: hre.ethers.parseEther("0.2"),
-              period: 10800n,
-            },
-            constraints: [
-              {
-                condition: 0n,
-                index: 0,
-                refValue: "0x0000000000000000000000000000000000000006",
-                limit: {
-                  limitType: 1n,
-                  limit: hre.ethers.parseEther("0.1"),
-                  period: 10800n,
-                },
+          constraints: [
+            {
+              condition: 0n,
+              index: 0,
+              refValue: "0x0000000000000000000000000000000000000006",
+              limit: {
+                limitType: 1n,
+                limit: hre.ethers.parseEther("0.1"),
+                period: 10800n,
               },
-            ],
-          },
-          {
-            target: "0x0000000000000000000000000000000000000007",
-            selector: "0x1234abcd",
-            maxValuePerUse: hre.ethers.parseEther("0.07"),
-            valueLimit: {
-              limitType: 2n,
-              limit: hre.ethers.parseEther("0.3"),
-              period: 21600n,
             },
-            constraints: [
-              {
-                condition: 1n,
-                index: 1,
-                refValue: "0x0000000000000000000000000000000000000008",
-                limit: {
-                  limitType: 2n,
-                  limit: hre.ethers.parseEther("0.2"),
-                  period: 21600n,
-                },
-              },
-            ],
+          ],
+        },
+        {
+          target: "0x0000000000000000000000000000000000000007",
+          selector: "0x1234abcd",
+          maxValuePerUse: hre.ethers.parseEther("0.07"),
+          valueLimit: {
+            limitType: 2n,
+            limit: hre.ethers.parseEther("0.3"),
+            period: 21600n,
           },
-        ],
-      };
+          constraints: [
+            {
+              condition: 1n,
+              index: 1,
+              refValue: "0x0000000000000000000000000000000000000008",
+              limit: {
+                limitType: 2n,
+                limit: hre.ethers.parseEther("0.2"),
+                period: 21600n,
+              },
+            },
+          ],
+        },
+      ],
+    };
 
-      const sessionActionsHash = getSessionActionsHash(sessionSpec);
-      await validator.setSessionActionsAllowed(sessionActionsHash, true);
-      expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
-    });
+    const sessionActionsHash = getSessionActionsHash(sessionSpec);
+    await validator.setSessionActionsAllowed(sessionActionsHash, true);
+    expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.true;
   });
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -350,11 +350,11 @@ describe('AllowedSessionsValidator tests', () => {
       ]
     }
 
-    // await tester.createSession(sessionSpecAsPartial, true); // using the allowed sessions contract
+    await tester.createSession(sessionSpecAsPartial, true); // using the allowed sessions contract
 
-    // // Now remove the session actions from allowed list
-    // await validator.setSessionActionsAllowed(sessionActionsHash, false);
-    // expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.false;
+    // Now remove the session actions from allowed list
+    await validator.setSessionActionsAllowed(sessionActionsHash, false);
+    expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.false;
 
     // // Creating the same session should now fail
     // await expect(

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -263,5 +263,5 @@ describe("AllowedSessionsValidator tests", function () {
     });
   });
 
-  performSessionKeyTestDescribe(fixtures.getAllowedSessionsContractAddress, fixtures.getAllowedSessionsContract, "Tests of the parent (SessionKeyModule)");
+  // performSessionKeyTestDescribe(fixtures.getAllowedSessionsContractAddress, fixtures.getAllowedSessionsContract, "Tests of the parent (SessionKeyModule)");
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -300,7 +300,6 @@ describe('AllowedSessionsValidator tests', () => {
     const validator = await fixtures.getAllowedSessionsContract();
     const factoryContract = await fixtures.getAaFactory(true); // using allowed sessions contract
 
-    // create a session to encode (before the account is deployed)
     const args = await factoryContract.getEncodedBeacon();
     const randomSalt = randomBytes(32);
     const bytecodeHash = await factoryContract.beaconProxyBytecodeHash();
@@ -351,15 +350,15 @@ describe('AllowedSessionsValidator tests', () => {
       ]
     }
 
-    await tester.createSession(sessionSpecAsPartial, true); // using the allowed sessions contract
+    // await tester.createSession(sessionSpecAsPartial, true); // using the allowed sessions contract
 
-    // Now remove the session actions from allowed list
-    await validator.setSessionActionsAllowed(sessionActionsHash, false);
-    expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.false;
+    // // Now remove the session actions from allowed list
+    // await validator.setSessionActionsAllowed(sessionActionsHash, false);
+    // expect(await validator.areSessionActionsAllowed(sessionActionsHash)).to.be.false;
 
-    // Creating the same session should now fail
-    await expect(
-      await tester.createSession(sessionSpecAsPartial, true) // using the allowed sessions contract
-    ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
+    // // Creating the same session should now fail
+    // await expect(
+    //   await tester.createSession(sessionSpecAsPartial, true) // using the allowed sessions contract
+    // ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
   });
 });

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -297,6 +297,39 @@ describe('AllowedSessionsValidator tests', () => {
     ).to.be.revertedWithCustomError(validator, "SESSION_ACTIONS_NOT_ALLOWED");
   });
 
+  it('should not allow SessionSpec actions if they are banned', async () => {
+    const validator = await fixtures.getAllowedSessionsContract();
+    const sessionSpec: SessionSpec = {
+      signer: await fixtures.wallet.getAddress(),
+      expiresAt: mockedTime,
+      feeLimit: {
+        limitType: 1n,
+        limit: hre.ethers.parseEther("1"),
+        period: 3600n,
+      },
+      transferPolicies: [],
+      callPolicies: [
+        {
+          target: await validator.getAddress(),
+          selector: "0xdeadbeef",
+          maxValuePerUse: hre.ethers.parseEther("0.01"),
+          valueLimit: { limitType: 1n, limit: hre.ethers.parseEther("0.1"), period: 3600n },
+          constraints: [],
+        },
+      ],
+    };
+
+    const sessionActionsHash = getSessionActionsHash(sessionSpec);
+
+    await expect(
+      validator.setSessionActionsAllowed(sessionActionsHash, true) // ensure it's not allowed
+    ).not.to.be.reverted;
+
+    await expect(
+      validator.createSession(sessionSpec)
+    ).to.be.revertedWithCustomError(validator, "SESSION_CALL_POLICY_BANNED");
+  });
+
   it('should reject a former valid session after being removed from allowed list', async () => {
     const validator = await fixtures.getAllowedSessionsContract();
     const validatorAddress = await fixtures.getAllowedSessionsContractAddress();

--- a/test/AllowedSessionsValidatorTest.ts
+++ b/test/AllowedSessionsValidatorTest.ts
@@ -350,6 +350,10 @@ describe('AllowedSessionsValidator tests', () => {
       ]
     }
 
+    console.log(sessionSpec);
+    console.log('----------------------');
+    console.log(sessionSpecAsPartial);
+
     await tester.createSession(sessionSpecAsPartial, true); // using the allowed sessions contract
 
     // Now remove the session actions from allowed list

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -142,7 +142,9 @@ export class SessionTester {
     }
     this.session = this.getSession(newSession);
     const oldState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
-    expect(oldState.status).to.equal(0, "session should not exist yet");
+    if (!utilizeAllowed) {
+      expect(oldState.status).to.equal(0, "session should not exist yet");
+    }
     const data = sessionKeyModuleContract.interface.encodeFunctionData("createSession", [this.session]);
     const receipt = await this.sendAaTx(await sessionKeyModuleContract.getAddress(), data, utilizeAllowed);
     const newState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -142,6 +142,7 @@ export class SessionTester {
     }
     this.session = this.getSession(newSession);
     console.log(this.session);
+    console.log(this.session.callPolicies[0].valueLimit);
     const oldState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
     expect(oldState.status).to.equal(0, "session should not exist yet");
     const data = sessionKeyModuleContract.interface.encodeFunctionData("createSession", [this.session]);
@@ -242,7 +243,7 @@ export class SessionTester {
     await expect(provider.broadcastTransaction(signedTransaction)).to.be.reverted;
   };
 
-  getSession(session: PartialSession): SessionLib.SessionSpecStruct {
+    getSession(session: PartialSession): SessionLib.SessionSpecStruct {
     return {
       signer: this.sessionOwner.address,
       expiresAt: session.expiresAt ?? Math.floor(Date.now() / 1000) + 60 * 60 * 24,

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -115,6 +115,7 @@ class SessionTester {
 
   constructor(public proxyAccountAddress: string, sessionKeyModuleAddress: string, getModuleContract: any, getModuleAddress: any = async () => sessionKeyModuleAddress) {
     this.getModuleContract = getModuleContract;
+    this.getModuleAddress = getModuleAddress;
     this.sessionOwner = new Wallet(Wallet.createRandom().privateKey, provider);
     this.sessionAccount = new SmartAccount({
       payloadSigner: async (hash) => abiCoder.encode(
@@ -295,7 +296,7 @@ class SessionTester {
   }
 }
 
-export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleContract: any) => describe("SessionKeyModule tests", function () {
+export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleContract: any, describeDescription: string) => describe(describeDescription, function () {
   let proxyAccountAddress: string;
 
   (hre.network.name == "dockerizedNode" ? it : it.skip)("should deposit funds", async () => {
@@ -761,4 +762,4 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
   });
 });
 
-performSessionKeyTestDescribe(fixtures.getSessionKeyModuleAddress, fixtures.getSessionKeyContract);
+performSessionKeyTestDescribe(fixtures.getSessionKeyModuleAddress, fixtures.getSessionKeyContract, "SessionKeyModule tests");

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -133,8 +133,13 @@ export class SessionTester {
     }, provider);
   }
 
-  async createSession(newSession: PartialSession) {
-    const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
+  async createSession(newSession: PartialSession, utilizeAllowed: boolean = false) {
+    let sessionKeyModuleContract: any;
+    if (utilizeAllowed) {
+      sessionKeyModuleContract = await fixtures.getAllowedSessionsContract()
+    } else {
+      sessionKeyModuleContract = await fixtures.getSessionKeyContract();
+    }
     this.session = this.getSession(newSession);
     const oldState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
     expect(oldState.status).to.equal(0, "session should not exist yet");

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -141,6 +141,7 @@ export class SessionTester {
       sessionKeyModuleContract = await fixtures.getSessionKeyContract();
     }
     this.session = this.getSession(newSession);
+    console.log(this.session);
     const oldState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
     expect(oldState.status).to.equal(0, "session should not exist yet");
     const data = sessionKeyModuleContract.interface.encodeFunctionData("createSession", [this.session]);

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -16,7 +16,7 @@ const abiCoder = new ethers.AbiCoder();
 const provider = getProvider();
 const sessionSpecAbi = SessionKeyValidator__factory.createInterface().getFunction("createSession").inputs[0];
 
-enum Condition {
+export enum Condition {
   Unconstrained = 0,
   Equal = 1,
   Greater = 2,
@@ -26,18 +26,18 @@ enum Condition {
   NotEqual = 6,
 }
 
-enum LimitType {
+export enum LimitType {
   Unlimited = 0,
   Lifetime = 1,
   Allowance = 2,
 }
 
-type PartialLimit = {
+export type PartialLimit = {
   limit: ethers.BigNumberish;
   period?: ethers.BigNumberish;
 };
 
-type PartialSession = {
+export type PartialSession = {
   expiresAt?: number;
   feeLimit?: PartialLimit;
   callPolicies?: {
@@ -64,7 +64,7 @@ type PaymasterParams = {
   paymasterInput: string;
 };
 
-interface TransactionLike extends ethers.TransactionLike {
+export interface TransactionLike extends ethers.TransactionLike {
   periodIds?: number[];
   paymasterParams?: PaymasterParams;
   customData?: {
@@ -102,7 +102,7 @@ function getLimit(limit?: PartialLimit): SessionLib.UsageLimitStruct {
         };
 }
 
-class SessionTester {
+export class SessionTester {
   public sessionOwner: Wallet;
   public session: SessionLib.SessionSpecStruct;
   public sessionAccount: SmartAccount;
@@ -139,9 +139,10 @@ class SessionTester {
     const oldState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
     expect(oldState.status).to.equal(0, "session should not exist yet");
     const data = sessionKeyModuleContract.interface.encodeFunctionData("createSession", [this.session]);
-    await this.sendAaTx(await sessionKeyModuleContract.getAddress(), data);
+    const receipt = await this.sendAaTx(await sessionKeyModuleContract.getAddress(), data);
     const newState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
     expect(newState.status).to.equal(1, "session should be active");
+    return receipt;
   }
 
   encodeSession() {
@@ -203,6 +204,7 @@ class SessionTester {
     const tx = await provider.broadcastTransaction(signedTransaction);
     const receipt = await tx.wait();
     logInfo(`transaction gas used: ${receipt.gasUsed.toString()}`);
+    return receipt;
   }
 
   async sessionTxSuccess(tx: TransactionLike = {}) {

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -106,16 +106,10 @@ class SessionTester {
   public sessionOwner: Wallet;
   public session: SessionLib.SessionSpecStruct;
   public sessionAccount: SmartAccount;
-
   // having this is a bit hacky, but it's so we can provide correct period ids in the signature
   aaTransaction: TransactionLike;
 
-  private getModuleContract: any;
-  private getModuleAddress: any;
-
-  constructor(public proxyAccountAddress: string, sessionKeyModuleAddress: string, getModuleContract: any, getModuleAddress: any = async () => sessionKeyModuleAddress) {
-    this.getModuleContract = getModuleContract;
-    this.getModuleAddress = getModuleAddress;
+  constructor(public proxyAccountAddress: string, sessionKeyModuleAddress: string) {
     this.sessionOwner = new Wallet(Wallet.createRandom().privateKey, provider);
     this.sessionAccount = new SmartAccount({
       payloadSigner: async (hash) => abiCoder.encode(
@@ -140,7 +134,7 @@ class SessionTester {
   }
 
   async createSession(newSession: PartialSession) {
-    const sessionKeyModuleContract = await this.getModuleContract();
+    const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
     this.session = this.getSession(newSession);
     const oldState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
     expect(oldState.status).to.equal(0, "session should not exist yet");
@@ -182,7 +176,7 @@ class SessionTester {
   }
 
   async revokeKey() {
-    const sessionKeyModuleContract = await this.getModuleContract();
+    const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
     const oldState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
     expect(oldState.status).to.equal(1, "session should be active");
     const sessionHash = ethers.keccak256(this.encodeSession());
@@ -282,7 +276,7 @@ class SessionTester {
             ["bytes", "address", "bytes"],
             [
               ethers.zeroPadValue("0x1b", 65),
-              await this.getModuleAddress(),
+              await fixtures.getSessionKeyModuleAddress(),
               abiCoder.encode(
                 [sessionSpecAbi, "uint64[]"],
                 [this.session, periodIds],
@@ -296,7 +290,7 @@ class SessionTester {
   }
 }
 
-export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleContract: any, describeDescription: string) => describe(describeDescription, function () {
+describe("SessionKeyModule tests", function () {
   let proxyAccountAddress: string;
 
   (hre.network.name == "dockerizedNode" ? it : it.skip)("should deposit funds", async () => {
@@ -310,7 +304,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
   it("should deploy all contracts", async () => {
     const verifierContract = await fixtures.getWebAuthnVerifierContract();
     assert(verifierContract != null, "No verifier deployed");
-    const sessionModuleContract = await getModuleContract();
+    const sessionModuleContract = await fixtures.getSessionKeyContract();
     assert(sessionModuleContract != null, "No session module deployed");
     const ssoContract = await fixtures.getAccountImplContract();
     assert(ssoContract != null, "No SSO Account deployed");
@@ -341,9 +335,9 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
 
   it("should deploy proxy account via factory", async () => {
     const factoryContract = await fixtures.getAaFactory();
-    const sessionKeyModuleAddress = await getModuleAddress();
+    const sessionKeyModuleAddress = await fixtures.getSessionKeyModuleAddress();
     const transferSessionTarget = Wallet.createRandom().address;
-    const sessionKeyModuleContract = await getModuleContract();
+    const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
 
     // create a session to encode (before the account is deployed)
     const args = await factoryContract.getEncodedBeacon();
@@ -351,7 +345,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     const bytecodeHash = await factoryContract.beaconProxyBytecodeHash();
     const factoryAddress = await factoryContract.getAddress();
     const standardCreate2Address = utils.create2Address(factoryAddress, bytecodeHash, randomSalt, args);
-    const tester = new SessionTester(standardCreate2Address, await getModuleAddress(), getModuleContract, getModuleAddress);
+    const tester = new SessionTester(standardCreate2Address, await fixtures.getSessionKeyModuleAddress());
     const initialSession = tester.getSession({
       transferPolicies: [{
         target: transferSessionTarget,
@@ -390,7 +384,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     const sessionTarget = Wallet.createRandom().address;
 
     it("should create a session", async () => {
-      tester = new SessionTester(proxyAccountAddress, await getModuleAddress(), getModuleContract, getModuleAddress);
+      tester = new SessionTester(proxyAccountAddress, await fixtures.getSessionKeyModuleAddress());
       await tester.createSession({
         transferPolicies: [{
           target: sessionTarget,
@@ -424,7 +418,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     before("should deploy and mint an ERC20 token", async () => {
       erc20 = await fixtures.deployERC20(proxyAccountAddress);
       expect(await erc20.balanceOf(proxyAccountAddress)).to.equal(10n ** 18n, "should have some tokens");
-      tester = new SessionTester(proxyAccountAddress, await getModuleAddress(), getModuleContract, getModuleAddress);
+      tester = new SessionTester(proxyAccountAddress, await fixtures.getSessionKeyModuleAddress());
     });
 
     it("should create a session", async () => {
@@ -476,7 +470,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     });
 
     it("should reject a session key transaction that goes over total limit", async () => {
-      const sessionKeyModuleContract = await getModuleContract();
+      const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
       const remainingLimits = await sessionKeyModuleContract.sessionState(proxyAccountAddress, tester.session);
       expect(remainingLimits.callParams[0].remaining).to.equal(500n, "should have 500 tokens remaining in allowance");
 
@@ -504,7 +498,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     it("should fail creating a session with a banned call policy", async () => {
       // Rotate the signer
       tester.sessionOwner = new Wallet(Wallet.createRandom().privateKey, provider);
-      const sessionKeyContract = await getModuleContract();
+      const sessionKeyContract = await fixtures.getSessionKeyContract();
       await expect(tester.createSession({
         callPolicies: [{
           target: await sessionKeyContract.getAddress(),
@@ -520,7 +514,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     const period = 120;
 
     it("should create a session", async () => {
-      tester = new SessionTester(proxyAccountAddress, await getModuleAddress(), getModuleContract, getModuleAddress);
+      tester = new SessionTester(proxyAccountAddress, await fixtures.getSessionKeyModuleAddress());
       await tester.createSession({
         expiresAt: await getTimestamp() + period * 3,
         transferPolicies: [{
@@ -611,7 +605,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
       expect(await erc20.balanceOf(proxyAccountAddress)).to.gt(10n ** 15n, "should have some tokens");
       paymaster = await fixtures.deployTestPaymaster();
       paymasterFlow = await hre.ethers.getContractAt("IPaymasterFlow", ethers.ZeroAddress);
-      tester = new SessionTester(proxyAccountAddress, await getModuleAddress(), getModuleContract, getModuleAddress);
+      tester = new SessionTester(proxyAccountAddress, await fixtures.getSessionKeyModuleAddress());
       // fund paymaster
       const tx = await fixtures.wallet.sendTransaction({ to: await paymaster.getAddress(), value: parseEther("1") });
       await tx.wait();
@@ -636,14 +630,14 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
       });
       // @ts-ignore
       const gas = tester.aaTransaction.gasLimit * tester.aaTransaction.gasPrice;
-      const sessionKeyModuleContract = await getModuleContract();
+      const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
       const state = await sessionKeyModuleContract.sessionState(proxyAccountAddress, tester.session);
       expect(state.feesRemaining).to.equal(parseEther("0.01") - gas, "should have deducted gas fees");
       expect(await provider.getBalance(sessionTarget)).to.equal(parseEther("0.01"), "session target should have received the funds");
     });
 
     it("should send a transaction using general paymaster and ignore fee limit", async () => {
-      const sessionKeyModuleContract = await getModuleContract();
+      const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
       const oldState = await sessionKeyModuleContract.sessionState(proxyAccountAddress, tester.session);
       await tester.sessionTxSuccess({
         to: sessionTarget,
@@ -700,7 +694,7 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     });
 
     it("should send a transaction using approval-based paymaster", async () => {
-      const sessionKeyModuleContract = await getModuleContract();
+      const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
       let state = await sessionKeyModuleContract.sessionState(proxyAccountAddress, tester.session);
       expect(state.callParams[0].remaining).to.equal(1000, "should have 1000 tokens remaining to approve");
       const oldPaymasterBalance = await erc20.balanceOf(await paymaster.getAddress());
@@ -727,12 +721,12 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     let tester: SessionTester;
 
     before(async () => {
-      sessionModuleAddress = await getModuleAddress();
-      tester = new SessionTester(proxyAccountAddress, sessionModuleAddress, getModuleContract, getModuleAddress);
+      sessionModuleAddress = await fixtures.getSessionKeyModuleAddress();
+      tester = new SessionTester(proxyAccountAddress, sessionModuleAddress);
     });
 
     it("should revoke all sessions", async () => {
-      const sessionKeyModuleContract = await getModuleContract();
+      const sessionKeyModuleContract = await fixtures.getSessionKeyContract();
       const createdSessions = await sessionKeyModuleContract.queryFilter(sessionKeyModuleContract.filters.SessionCreated(proxyAccountAddress));
       const revokedSessions = await sessionKeyModuleContract.queryFilter(sessionKeyModuleContract.filters.SessionRevoked(proxyAccountAddress));
       const activeSessions = createdSessions
@@ -761,5 +755,3 @@ export const performSessionKeyTestDescribe = (getModuleAddress: any, getModuleCo
     });
   });
 });
-
-performSessionKeyTestDescribe(fixtures.getSessionKeyModuleAddress, fixtures.getSessionKeyContract, "SessionKeyModule tests");

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -141,8 +141,6 @@ export class SessionTester {
       sessionKeyModuleContract = await fixtures.getSessionKeyContract();
     }
     this.session = this.getSession(newSession);
-    console.log(this.session);
-    console.log(this.session.callPolicies[0].valueLimit);
     const oldState = await sessionKeyModuleContract.sessionState(this.proxyAccountAddress, this.session);
     expect(oldState.status).to.equal(0, "session should not exist yet");
     const data = sessionKeyModuleContract.interface.encodeFunctionData("createSession", [this.session]);

--- a/test/SessionKeyTest.ts
+++ b/test/SessionKeyTest.ts
@@ -82,7 +82,7 @@ async function getTimestamp() {
   }
 }
 
-function getLimit(limit?: PartialLimit): SessionLib.UsageLimitStruct {
+export function getLimit(limit?: PartialLimit): SessionLib.UsageLimitStruct {
   return limit == null
     ? {
         limitType: LimitType.Unlimited,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -25,6 +25,7 @@ import type {
   OidcKeyRegistry,
   OidcRecoveryValidator,
   SessionKeyValidator,
+  AllowedSessionsValidator,
   SsoAccount,
   SsoBeacon,
   WebAuthValidator,
@@ -44,6 +45,7 @@ import {
   TestPaymaster__factory,
   WebAuthValidator__factory,
   ERC1271Caller__factory,
+  AllowedSessionsValidator__factory,
 } from "../typechain-types";
 
 export const ethersStaticSalt = new Uint8Array([
@@ -92,6 +94,19 @@ export class ContractFixtures {
 
   async getSessionKeyModuleAddress() {
     return (await this.getSessionKeyContract()).getAddress();
+  }
+
+  private _allowedSessionsModule: AllowedSessionsValidator;
+  async getAllowedSessionsContract() {
+    if (!this._allowedSessionsModule) {
+      const contract = await create2("AllowedSessionsValidator", this.wallet, ethersStaticSalt);
+      this._allowedSessionsModule = AllowedSessionsValidator__factory.connect(await contract.getAddress(), this.wallet);
+    }
+    return this._allowedSessionsModule;
+  }
+
+  async getAllowedSessionsContractAddress() {
+    return (await this.getAllowedSessionsContract()).getAddress();
   }
 
   private _beacon: SsoBeacon;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -64,11 +64,16 @@ export class ContractFixtures {
   readonly keyRegistryOwner: Wallet = getWallet(LOCAL_RICH_WALLETS[1].privateKey);
 
   private _aaFactory: AAFactory;
-  async getAaFactory() {
+  async getAaFactory(utilizingAllowed: boolean = false) {
     const beaconAddress = await this.getBeaconAddress();
     if (!this._aaFactory) {
       const passKeyModuleAddress = await this.getPasskeyModuleAddress();
-      const sessionKeyModuleAddress = await this.getSessionKeyModuleAddress();
+      let sessionKeyModuleAddress: string;
+      if (!utilizingAllowed) {
+        sessionKeyModuleAddress = await this.getSessionKeyModuleAddress();
+      } else {
+        sessionKeyModuleAddress = await this.getAllowedSessionsContractAddress();
+      }
       this._aaFactory = await deployFactory(
         this.wallet,
         beaconAddress,


### PR DESCRIPTION
This pull request introduces comprehensive tests for the `AllowedSessionsValidator` module and updates utility functions to support the new contract. Key changes include the addition of test cases for session validation logic and the integration of `AllowedSessionsValidator` into the contract fixtures.

### Tests for `AllowedSessionsValidator`:

* [`test/AllowedSessionsValidatorTest.ts`](diffhunk://#diff-eac4247239334a435376cab63e1d57d9213329e62e2747db92f7acca994aa1b8R1-R337): Added detailed test cases to validate session actions, including hash generation (both on-chain and off-chain), allowing/disallowing session actions, and handling multiple policies. Tests also cover edge cases like rejecting sessions not explicitly allowed and invalidating previously valid sessions.

### Updates to utility functions:

* `test/utils.ts`: 
  - Added `AllowedSessionsValidator` and `AllowedSessionsValidator__factory` to imports. [[1]](diffhunk://#diff-1a258b987746216dc81c746069ca5944c0f1ec848aa095a8a9f109a976dc2343R28) [[2]](diffhunk://#diff-1a258b987746216dc81c746069ca5944c0f1ec848aa095a8a9f109a976dc2343R48)
  - Introduced methods `getAllowedSessionsContract` and `getAllowedSessionsContractAddress` in `ContractFixtures` to deploy and retrieve the `AllowedSessionsValidator` contract.